### PR TITLE
Claude/naughty chaum 0f808c

### DIFF
--- a/netty-loom-spring-boot-starter/src/test/java/io/azholdaspaev/nettyloom/autoconfigure/smoke/app/SmokeController.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/azholdaspaev/nettyloom/autoconfigure/smoke/app/SmokeController.java
@@ -1,6 +1,8 @@
 package io.azholdaspaev.nettyloom.autoconfigure.smoke.app;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -40,6 +42,11 @@ public class SmokeController {
     @GetMapping("/api/whoami")
     public String whoami(@RequestHeader("X-User") String user) {
         return user;
+    }
+
+    @GetMapping("/api/headers/date")
+    public void dateHeader(HttpServletResponse response) {
+        response.setDateHeader(HttpHeaders.LAST_MODIFIED, 0L);
     }
 
     public record Greeting(String message) {

--- a/netty-loom-spring-boot-starter/src/test/java/io/azholdaspaev/nettyloom/autoconfigure/smoke/test/SmokeControllerTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/azholdaspaev/nettyloom/autoconfigure/smoke/test/SmokeControllerTest.java
@@ -4,6 +4,7 @@ import io.azholdaspaev.nettyloom.autoconfigure.smoke.app.SmokeController.Greetin
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.client.RestTestClient;
@@ -91,5 +92,14 @@ class SmokeControllerTest extends BaseIntegrationTest {
             .header("Accept", "text/csv")
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void shouldFormatDateHeaderAsRfc1123() {
+        restTestClient.get().uri("/api/headers/date")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().valueEquals(HttpHeaders.LAST_MODIFIED, "Thu, 01 Jan 1970 00:00:00 GMT");
     }
 }

--- a/netty-loom-spring-mvc/src/main/java/io/azholdaspaev/nettyloom/mvc/servlet/NettyHttpServletResponse.java
+++ b/netty-loom-spring-mvc/src/main/java/io/azholdaspaev/nettyloom/mvc/servlet/NettyHttpServletResponse.java
@@ -1,6 +1,7 @@
 package io.azholdaspaev.nettyloom.mvc.servlet;
 
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -21,6 +22,7 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -70,12 +72,12 @@ public class NettyHttpServletResponse implements HttpServletResponse {
 
     @Override
     public void setDateHeader(String name, long date) {
-        setHeader(name, Long.toString(date));
+        setHeader(name, DateFormatter.format(new Date(date)));
     }
 
     @Override
     public void addDateHeader(String name, long date) {
-        addHeader(name, Long.toString(date));
+        addHeader(name, DateFormatter.format(new Date(date)));
     }
 
     @Override


### PR DESCRIPTION
setDateHeader and addDateHeader previously wrote raw epoch-millisecond values, which violates RFC 9110 and cannot be parsed by the symmetric DateFormatter.parseHttpDate used on the request side. Format via Netty's DateFormatter so responses round-trip through the request-side parser and remain interoperable with clients and caching intermediaries.