### PR TITLE
Expose Netty server tunables via server.netty.* properties

### DIFF
--- a/netty-loom-spring-boot-starter/src/main/java/io/azholdaspaev/nettyloom/autoconfigure/NettyLoomAutoConfiguration.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/azholdaspaev/nettyloom/autoconfigure/NettyLoomAutoConfiguration.java
@@ -1,5 +1,6 @@
 package io.azholdaspaev.nettyloom.autoconfigure;
 
+import io.azholdaspaev.nettyloom.autoconfigure.properties.NettyLoomProperties;
 import io.azholdaspaev.nettyloom.autoconfigure.server.NettyWebServerFactory;
 import io.azholdaspaev.nettyloom.core.handler.HttpRequestDispatcher;
 import io.azholdaspaev.nettyloom.core.handler.HttpRequestHandler;
@@ -15,6 +16,7 @@ import io.azholdaspaev.nettyloom.mvc.servlet.NettyServletContext;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.DispatcherServlet;
@@ -22,6 +24,7 @@ import org.springframework.web.servlet.DispatcherServlet;
 import java.util.List;
 
 @AutoConfiguration(before = WebMvcAutoConfiguration.class)
+@EnableConfigurationProperties(NettyLoomProperties.class)
 public class NettyLoomAutoConfiguration {
 
     private static final int MAX_HTTP_REQUEST_BODY_BYTES = 1024 * 1024;
@@ -34,8 +37,12 @@ public class NettyLoomAutoConfiguration {
     }
 
     @Bean
-    public NettyServer nettyServer(NettyServerChannelInitializer nettyServerChannelInitializer) {
-        return new NettyServer(new NettyServerConfiguration(0), nettyServerChannelInitializer);
+    public NettyServer nettyServer(NettyLoomProperties properties,
+                                   NettyServerChannelInitializer nettyServerChannelInitializer) {
+        NettyServerConfiguration configuration = new NettyServerConfiguration(
+            properties.port(), properties.bossThreads(), properties.workerThreads(), properties.keepAlive()
+        );
+        return new NettyServer(configuration, nettyServerChannelInitializer);
     }
 
     @Bean

--- a/netty-loom-spring-boot-starter/src/main/java/io/azholdaspaev/nettyloom/autoconfigure/properties/NettyLoomProperties.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/azholdaspaev/nettyloom/autoconfigure/properties/NettyLoomProperties.java
@@ -1,0 +1,12 @@
+package io.azholdaspaev.nettyloom.autoconfigure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties("server.netty")
+public record NettyLoomProperties(
+    @DefaultValue("0") int port,
+    @DefaultValue("1") int bossThreads,
+    @DefaultValue("0") int workerThreads,
+    @DefaultValue("true") boolean keepAlive
+) {}

--- a/netty-loom-spring-core/src/main/java/io/azholdaspaev/nettyloom/core/server/NettyServer.java
+++ b/netty-loom-spring-core/src/main/java/io/azholdaspaev/nettyloom/core/server/NettyServer.java
@@ -37,18 +37,18 @@ public class NettyServer {
                 return;
             }
 
-            bossGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
-            workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+            bossGroup = new MultiThreadIoEventLoopGroup(configuration.bossThreads(), NioIoHandler.newFactory());
+            workerGroup = new MultiThreadIoEventLoopGroup(configuration.workerThreads(), NioIoHandler.newFactory());
 
             ServerBootstrap bootstrap = new ServerBootstrap();
             bootstrap.group(bossGroup, workerGroup)
                 .channel(NioServerSocketChannel.class)
                 .childHandler(channelInitializer)
                 .option(ChannelOption.SO_BACKLOG, 128)
-                .childOption(ChannelOption.SO_KEEPALIVE, true);
+                .childOption(ChannelOption.SO_KEEPALIVE, configuration.keepAlive());
 
             try {
-                ChannelFuture bindFuture = bootstrap.bind(configuration.getPort()).sync();
+                ChannelFuture bindFuture = bootstrap.bind(configuration.port()).sync();
                 serverChannel = bindFuture.channel();
                 state = true;
             } catch (InterruptedException e) {
@@ -103,7 +103,7 @@ public class NettyServer {
 
     public int getPort() {
         InetSocketAddress address = resolvedAddress();
-        return address == null ? configuration.getPort() : address.getPort();
+        return address == null ? configuration.port() : address.getPort();
     }
 
     public boolean isRunning() {

--- a/netty-loom-spring-core/src/main/java/io/azholdaspaev/nettyloom/core/server/NettyServerConfiguration.java
+++ b/netty-loom-spring-core/src/main/java/io/azholdaspaev/nettyloom/core/server/NettyServerConfiguration.java
@@ -1,14 +1,8 @@
 package io.azholdaspaev.nettyloom.core.server;
 
-public class NettyServerConfiguration {
-
-    private final int port;
-
-    public NettyServerConfiguration(int port) {
-        this.port = port;
-    }
-
-    public int getPort() {
-        return port;
-    }
-}
+public record NettyServerConfiguration(
+    int port,
+    int bossThreads,
+    int workerThreads,
+    boolean keepAlive
+) {}

--- a/netty-loom-spring-core/src/test/java/io/azholdaspaev/nettyloom/core/server/NettyServerTest.java
+++ b/netty-loom-spring-core/src/test/java/io/azholdaspaev/nettyloom/core/server/NettyServerTest.java
@@ -18,7 +18,7 @@ class NettyServerTest {
 
     @BeforeEach
     void setup() {
-        NettyServerConfiguration configuration = new NettyServerConfiguration(0);
+        NettyServerConfiguration configuration = new NettyServerConfiguration(0, 0, 0, false);
         NettyPipelineConfigurer pipelineConfigurer = new DefaultNettyPipelineConfigurer(List.of());
         NettyServerChannelInitializer channelInitializer = new NettyServerChannelInitializer(pipelineConfigurer);
         nettyServer = new NettyServer(configuration, channelInitializer);


### PR DESCRIPTION
Introduce NettyLoomProperties bound to server.netty (port, boss/worker threads, keep-alive) and thread the values through NettyServerConfiguration so operators can size the event loops and toggle SO_KEEPALIVE without code changes. Convert NettyServerConfiguration to a record for the expanded shape.