### PR TITLE
Harden the Tomcat-vs-Netty benchmark: remove accept-ceiling confound + report CPU efficiency

### DIFF
--- a/netty-loom-spring-benchmarks/README.md
+++ b/netty-loom-spring-benchmarks/README.md
@@ -151,8 +151,17 @@ k6 run --env BASE_URL=http://localhost:18080 --env VUS=10000 k6/high-concurrency
   server saturates, slow responses throttle the offered load, so a dying server can look merely "slow"
   rather than overloaded. For the honest tail, also run an *open* model that holds offered RPS fixed
   (k6 `constant-arrival-rate`) and watch errors instead of latency.
-- **Same box = contention.** At 10k+ VUs the k6 client steals CPU from the server; numbers are partly
-  client-bound. The two-host setup above is the only fully defensible configuration.
+- **Same box = contention — so we report CPU per target.** At 10k+ VUs the k6 client steals CPU from
+  the server; raw throughput is partly client-bound. Part of Netty-Loom's edge is a leaner per-request
+  pipeline, and on a contended box "cheaper per request" converts directly into "grabs more of the
+  shared cores than k6 leaves for Tomcat." The **CPU efficiency** table in the snapshot is the cheap
+  discriminator: it reports each server's average cores used (Δ cumulative CPU time / Δ wall over the
+  load window) and **throughput per core**. Throughput-per-core is allocation-independent — if
+  Netty-Loom serves more requests *per core* than Tomcat+VT, the win is structural and should survive
+  going off-box; if it wins only by pinning more cores, that component is a contention artifact that
+  off-box testing would compress (though the structural I/O-parallelism / poller advantage should
+  persist). The two-host setup above remains the only fully defensible configuration; the CPU column
+  tells you, on a single box, which story the numbers are telling.
 - **Warmup/JIT and GC** are pinned the same way across all three (identical `JAVA_FLAGS`, a warmup ramp
   that's trimmed) so a difference can't be misattributed to the server model.
 

--- a/netty-loom-spring-benchmarks/README.md
+++ b/netty-loom-spring-benchmarks/README.md
@@ -26,6 +26,14 @@ The apps live in [`netty-loom-spring-example-netty`](../netty-loom-spring-exampl
 [`netty-loom-spring-example-tomcat`](../netty-loom-spring-example-tomcat) (the Tomcat one is launched
 twice with different Spring profiles, `platform` and `virtual`).
 
+Both Tomcat targets run with `server.tomcat.max-connections` raised above the connection count
+(`run-all.sh` sets it to `2 × VUS`). This is **not** tuning Tomcat to win — it removes a confound:
+Tomcat's connector defaults to `max-connections=8192`, an established-connection cap that
+`spring.threads.virtual.enabled` does **not** raise (the flag only swaps the request executor for a
+`VirtualThreadExecutor`). Left at the default, ~1,800 of 10k connections would be reset/queued at the
+accept ceiling — a config artifact masquerading as an architectural limit. See
+[Interpreting results](#interpreting-results--and-how-to-keep-yourself-honest).
+
 Endpoints:
 - `GET /ping` → `pong` — minimal work, for raw throughput.
 - `GET /work` → `Thread.sleep(50)` then small JSON — a **blocking** 50ms call simulating a database
@@ -119,6 +127,19 @@ k6 run --env BASE_URL=http://localhost:18080 --env VUS=10000 k6/high-concurrency
 
 ## Interpreting results — and how to keep yourself honest
 
+- **Tomcat's accept ceiling is config, not architecture — so we raise it.** Tomcat's NIO connector
+  defaults to `max-connections=8192` and `threads.max=200`. Enabling virtual threads
+  (`spring.threads.virtual.enabled=true`) replaces the worker pool with a `VirtualThreadExecutor` but
+  leaves the acceptor, poller, and `max-connections` untouched (verified in spring-boot-tomcat 4.0.5's
+  `TomcatVirtualThreadsWebServerFactoryCustomizer`). At 10k connections, the default would reset/queue
+  ~1,800 of them at the accept ceiling, producing a tail-latency + error-rate collapse that's a config
+  artifact, not an architectural one. `run-all.sh` therefore sets `max-connections = 2 × VUS` on both
+  Tomcat targets, and raises `threads.max` to match on the **virtual** target (its executor isn't
+  pool-bounded, but this forecloses the "you throttled the VT path" objection). The **platform** target
+  keeps `threads.max=200` — the bounded thread-per-request pool *is* the architecture under test. The
+  OS backlog (`accept-count=100`) is left at its default, ≈ Netty core's hardcoded `SO_BACKLOG=128`, and
+  isn't the bottleneck under the 15s gradual ramp. Whatever gap survives this is architecture; the
+  earlier default-config snapshot is in git history (commit `c4f4270`) for a before/after comparison.
 - **Memory per connection is noise-dominated at low VU counts.** With `-Xmx2g` and no `-Xms`, G1 commits
   heap lazily, so RSS jumps ~100MB from GC/JIT regardless of connections. The metric only separates the
   targets once connections vastly outnumber the ~200-thread pool. The snapshot uses the steady-state

--- a/netty-loom-spring-benchmarks/results/SNAPSHOT.md
+++ b/netty-loom-spring-benchmarks/results/SNAPSHOT.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-06-13
 - **Machine:** `Darwin 25.5.0 arm64`
 - **JVM flags (identical for all targets):** `-XX:+UseG1GC -Xmx2g -XX:NativeMemoryTracking=summary`
+- **Logical cores:** 8 (client and server share this box — see CPU efficiency below)
 - **Tomcat connector:** `max-connections=20000` on both Tomcat targets, and `threads.max=20000` on the virtual target (platform keeps the default `threads.max=200` — the thread-per-request pool under test). Raised above the connection count so Tomcat's default `max-connections=8192` accept ceiling — which `spring.threads.virtual.enabled` does not touch — isn't the confound.
 - **High-concurrency connections (VUs):** 10,000
 - **Workload:** `GET /work` → `Thread.sleep(50)` (simulated 50ms blocking DB call); keep-alive on, so 1 VU ≈ 1 connection ≈ 1 in-flight request.
@@ -13,37 +14,50 @@
 
 At **10,000 concurrent blocking connections**:
 
-- **Throughput:** Netty-Loom 37,090 req/s vs Tomcat+VT 11,934 vs Tomcat-platform 3,631 req/s.
-- **Tail latency (p99):** Netty-Loom 578 ms vs Tomcat+VT 5,924 ms (10.3×) vs Tomcat-platform 2,869 ms (5.0×).
+- **Throughput:** Netty-Loom 41,412 req/s vs Tomcat+VT 12,640 vs Tomcat-platform 3,834 req/s.
+- **Tail latency (p99):** Netty-Loom 447 ms vs Tomcat+VT 5,417 ms (12.1×) vs Tomcat-platform 2,653 ms (5.9×).
 - **Error rate:** Netty-Loom 0.00% vs Tomcat+VT 0.00% vs Tomcat-platform 0.00%.
+- **CPU efficiency:** Netty-Loom 1.8 cores → 22,908 req/s per core vs Tomcat+VT 2.2 cores → 5,734 req/s per core.
 
 **Does flipping `spring.threads.virtual.enabled=true` on Tomcat close the gap?** On this workload, **no** — Netty-Loom still wins on throughput, p99 tail, and error rate. The wedge is more than a Tomcat config flag.
 
-> Single-box loopback numbers: the k6 client contends with the server for CPU, so absolute latencies are inflated and the comparison is relative, not absolute. See [README](../README.md) caveats.
+**Is the throughput edge structural or a single-box contention artifact?** Structural: Netty-Loom does more work *per core* (22,908 vs 5,734 req/s/core), so the win isn't merely from grabbing cores k6 left idle. Off-box, raw per-request efficiency may compress, but a per-core advantage like this should persist.
+
+> Single-box loopback numbers: the k6 client contends with the server for CPU, so absolute latencies are inflated and the comparison is relative, not absolute. The CPU efficiency table is the discriminator for what survives off-box. See [README](../README.md) caveats.
 
 ## Scenario 1 — low-concurrency throughput (1→10 VUs, `GET /ping`)
 
 | Target | Throughput (req/s) | p50 (ms) | p95 (ms) | p99 (ms) | Error rate |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| Netty-Loom (this library) | 27516 | 0.1 | 0.2 | 0.3 | 0.00% |
-| Tomcat, platform threads | 28297 | 0.1 | 0.2 | 0.3 | 0.00% |
-| Tomcat, virtual threads | 27932 | 0.1 | 0.2 | 0.3 | 0.00% |
+| Netty-Loom (this library) | 25782 | 0.1 | 0.2 | 0.4 | 0.00% |
+| Tomcat, platform threads | 26032 | 0.1 | 0.2 | 0.4 | 0.00% |
+| Tomcat, virtual threads | 25913 | 0.1 | 0.2 | 0.4 | 0.00% |
 
 ## Scenario 2 — high-concurrency blocking I/O (10,000 VUs, `GET /work`)
 
 | Target | Throughput (req/s) | p50 (ms) | p95 (ms) | p99 (ms) | Error rate |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| Netty-Loom (this library) | 37090 | 155.5 | 444.5 | 577.7 | 0.00% |
-| Tomcat, platform threads | 3631 | 2776.6 | 2848.3 | 2869.1 | 0.00% |
-| Tomcat, virtual threads | 11934 | 86.0 | 4066.8 | 5924.2 | 0.00% |
+| Netty-Loom (this library) | 41412 | 170.6 | 392.2 | 446.7 | 0.00% |
+| Tomcat, platform threads | 3834 | 2607.6 | 2642.9 | 2652.7 | 0.00% |
+| Tomcat, virtual threads | 12640 | 95.3 | 3232.7 | 5416.8 | 0.00% |
+
+## CPU efficiency (server-side, during the 10,000-connection run)
+
+| Target | Throughput (req/s) | CPU (avg cores) | CPU util % (of 8) | Throughput / core (req/s) |
+| --- | ---: | ---: | ---: | ---: |
+| Netty-Loom (this library) | 41412 | 1.81 | 22.6% | 22908 |
+| Tomcat, platform threads | 3834 | 0.32 | 4.1% | 11799 |
+| Tomcat, virtual threads | 12640 | 2.20 | 27.6% | 5734 |
+
+Server-process CPU only (the k6 client is a separate process). **CPU (avg cores)** = Δ(cumulative CPU time) / Δ(wall clock) over the load window, so it counts only CPU burned while serving the load, not startup/JIT. **Throughput / core** is the discriminator: at 10,000 connections the client and server contend for the same 8 cores, so raw throughput partly reflects who grabbed more cores. Throughput-per-core is allocation-independent — a higher value means more requests served per core of work, an efficiency edge that should survive moving the client off-box. A target can post high throughput simply by pinning more cores; only a higher throughput-per-core says the win is structural.
 
 ## Memory per connection (under 10,000 concurrent connections)
 
 | Target | Idle RSS (MB) | Loaded RSS median (MB) | Loaded RSS peak (MB) | Δ RSS median (MB) | Memory / connection (KB) |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| Netty-Loom (this library) | 178.7 | 346.8 | 435.8 | 168.0 | 17.21 |
-| Tomcat, platform threads | 200.0 | 429.0 | 522.2 | 229.0 | 23.45 |
-| Tomcat, virtual threads | 206.7 | 1358.3 | 1874.0 | 1151.6 | 117.92 |
+| Netty-Loom (this library) | 200.4 | 397.4 | 540.1 | 197.0 | 20.17 |
+| Tomcat, platform threads | 213.0 | 499.0 | 639.0 | 286.0 | 29.29 |
+| Tomcat, virtual threads | 210.5 | 1660.7 | 1893.4 | 1450.2 | 148.50 |
 
 RSS includes committed heap, thread stacks, and Netty direct buffers. `Memory / connection = (loaded RSS median − idle RSS median) / connections`, using the steady-state median rather than the transient peak to suppress G1 heap-commit/JIT jitter (a ~100MB noise floor with `-Xmx2g` and no `-Xms`). At low connection counts this metric is noise-dominated and not meaningful; it only separates the targets once connections vastly outnumber the platform-thread pool (~200). Near-zero or negative values mean per-connection growth was below the noise floor — expected for virtual-thread targets whose parked continuations are cheap. Note the platform-thread target's footprint does **not** scale with offered connections: it caps at ~200 worker threads and refuses/queues the rest, so it can look memory-frugal while collapsing on latency and error rate above.
 

--- a/netty-loom-spring-benchmarks/results/SNAPSHOT.md
+++ b/netty-loom-spring-benchmarks/results/SNAPSHOT.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-06-13
 - **Machine:** `Darwin 25.5.0 arm64`
 - **JVM flags (identical for all targets):** `-XX:+UseG1GC -Xmx2g -XX:NativeMemoryTracking=summary`
+- **Tomcat connector:** `max-connections=20000` on both Tomcat targets, and `threads.max=20000` on the virtual target (platform keeps the default `threads.max=200` — the thread-per-request pool under test). Raised above the connection count so Tomcat's default `max-connections=8192` accept ceiling — which `spring.threads.virtual.enabled` does not touch — isn't the confound.
 - **High-concurrency connections (VUs):** 10,000
 - **Workload:** `GET /work` → `Thread.sleep(50)` (simulated 50ms blocking DB call); keep-alive on, so 1 VU ≈ 1 connection ≈ 1 in-flight request.
 
@@ -12,9 +13,9 @@
 
 At **10,000 concurrent blocking connections**:
 
-- **Throughput:** Netty-Loom 38,082 req/s vs Tomcat+VT 11,471 vs Tomcat-platform 3,798 req/s.
-- **Tail latency (p99):** Netty-Loom 620 ms vs Tomcat+VT 6,372 ms (10.3×) vs Tomcat-platform 2,455 ms (4.0×).
-- **Error rate:** Netty-Loom 0.00% vs Tomcat+VT 1.15% vs Tomcat-platform 4.68%.
+- **Throughput:** Netty-Loom 37,090 req/s vs Tomcat+VT 11,934 vs Tomcat-platform 3,631 req/s.
+- **Tail latency (p99):** Netty-Loom 578 ms vs Tomcat+VT 5,924 ms (10.3×) vs Tomcat-platform 2,869 ms (5.0×).
+- **Error rate:** Netty-Loom 0.00% vs Tomcat+VT 0.00% vs Tomcat-platform 0.00%.
 
 **Does flipping `spring.threads.virtual.enabled=true` on Tomcat close the gap?** On this workload, **no** — Netty-Loom still wins on throughput, p99 tail, and error rate. The wedge is more than a Tomcat config flag.
 
@@ -24,25 +25,25 @@ At **10,000 concurrent blocking connections**:
 
 | Target | Throughput (req/s) | p50 (ms) | p95 (ms) | p99 (ms) | Error rate |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| Netty-Loom (this library) | 26391 | 0.1 | 0.2 | 0.4 | 0.00% |
-| Tomcat, platform threads | 28910 | 0.1 | 0.2 | 0.3 | 0.00% |
-| Tomcat, virtual threads | 28187 | 0.1 | 0.2 | 0.3 | 0.00% |
+| Netty-Loom (this library) | 27516 | 0.1 | 0.2 | 0.3 | 0.00% |
+| Tomcat, platform threads | 28297 | 0.1 | 0.2 | 0.3 | 0.00% |
+| Tomcat, virtual threads | 27932 | 0.1 | 0.2 | 0.3 | 0.00% |
 
 ## Scenario 2 — high-concurrency blocking I/O (10,000 VUs, `GET /work`)
 
 | Target | Throughput (req/s) | p50 (ms) | p95 (ms) | p99 (ms) | Error rate |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| Netty-Loom (this library) | 38082 | 162.1 | 449.4 | 619.9 | 0.00% |
-| Tomcat, platform threads | 3798 | 2227.3 | 2426.3 | 2455.1 | 4.68% |
-| Tomcat, virtual threads | 11471 | 96.8 | 4822.1 | 6372.3 | 1.15% |
+| Netty-Loom (this library) | 37090 | 155.5 | 444.5 | 577.7 | 0.00% |
+| Tomcat, platform threads | 3631 | 2776.6 | 2848.3 | 2869.1 | 0.00% |
+| Tomcat, virtual threads | 11934 | 86.0 | 4066.8 | 5924.2 | 0.00% |
 
 ## Memory per connection (under 10,000 concurrent connections)
 
 | Target | Idle RSS (MB) | Loaded RSS median (MB) | Loaded RSS peak (MB) | Δ RSS median (MB) | Memory / connection (KB) |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| Netty-Loom (this library) | 177.5 | 337.4 | 418.2 | 159.9 | 16.37 |
-| Tomcat, platform threads | 212.9 | 411.8 | 454.9 | 198.9 | 20.36 |
-| Tomcat, virtual threads | 208.5 | 1357.6 | 1847.7 | 1149.1 | 117.67 |
+| Netty-Loom (this library) | 178.7 | 346.8 | 435.8 | 168.0 | 17.21 |
+| Tomcat, platform threads | 200.0 | 429.0 | 522.2 | 229.0 | 23.45 |
+| Tomcat, virtual threads | 206.7 | 1358.3 | 1874.0 | 1151.6 | 117.92 |
 
 RSS includes committed heap, thread stacks, and Netty direct buffers. `Memory / connection = (loaded RSS median − idle RSS median) / connections`, using the steady-state median rather than the transient peak to suppress G1 heap-commit/JIT jitter (a ~100MB noise floor with `-Xmx2g` and no `-Xms`). At low connection counts this metric is noise-dominated and not meaningful; it only separates the targets once connections vastly outnumber the platform-thread pool (~200). Near-zero or negative values mean per-connection growth was below the noise floor — expected for virtual-thread targets whose parked continuations are cheap. Note the platform-thread target's footprint does **not** scale with offered connections: it caps at ~200 worker threads and refuses/queues the rest, so it can look memory-frugal while collapsing on latency and error rate above.
 

--- a/netty-loom-spring-benchmarks/scripts/run-all.sh
+++ b/netty-loom-spring-benchmarks/scripts/run-all.sh
@@ -35,6 +35,12 @@ SETTLE="${SETTLE:-10}"
 # Identical flags for every target so the memory comparison is apples-to-apples. No -Xms, so
 # committed heap (and thus RSS) grows with real usage rather than being pre-committed away.
 JAVA_FLAGS="${JAVA_FLAGS:--XX:+UseG1GC -Xmx2g -XX:NativeMemoryTracking=summary}"
+# Tomcat's connector defaults to maxConnections=8192 — an established-connection cap that
+# spring.threads.virtual.enabled does NOT raise. At VUS connections, the overflow is reset/
+# queued and shows up as a tail-latency + error-rate collapse that's config, not architecture.
+# Raise the cap well above the offered load so the comparison reflects architecture. The VT
+# target also gets threads.max raised (its executor isn't pool-bounded, but this is explicit).
+TOMCAT_MAXCONN=$(( VUS * 2 ))
 
 # Resolve the bootJars by glob so a version bump doesn't silently break the run. The plain
 # (-plain.jar) artifact is filtered out; the boot-packaged jar is the runnable one.
@@ -95,10 +101,12 @@ benchmark_target() {
 }
 
 benchmark_target "netty-loom"      18080 -jar "$NETTY_JAR"
-benchmark_target "tomcat-platform" 18081 -jar "$TOMCAT_JAR" --spring.profiles.active=platform
-benchmark_target "tomcat-virtual"  18082 -jar "$TOMCAT_JAR" --spring.profiles.active=virtual
+benchmark_target "tomcat-platform" 18081 -jar "$TOMCAT_JAR" --spring.profiles.active=platform \
+  --server.tomcat.max-connections="$TOMCAT_MAXCONN"
+benchmark_target "tomcat-virtual"  18082 -jar "$TOMCAT_JAR" --spring.profiles.active=virtual \
+  --server.tomcat.max-connections="$TOMCAT_MAXCONN" --server.tomcat.threads.max="$TOMCAT_MAXCONN"
 
 echo "================ summarizing ================"
 UNAME=$(uname -srm)
-python3 "$SCRIPT_DIR/summarize.py" "$RESULTS" "$VUS" "$JAVA_FLAGS" "$UNAME" > "$RESULTS/SNAPSHOT.md"
+python3 "$SCRIPT_DIR/summarize.py" "$RESULTS" "$VUS" "$JAVA_FLAGS" "$UNAME" "$TOMCAT_MAXCONN" > "$RESULTS/SNAPSHOT.md"
 echo "wrote $RESULTS/SNAPSHOT.md"

--- a/netty-loom-spring-benchmarks/scripts/sample-memory.sh
+++ b/netty-loom-spring-benchmarks/scripts/sample-memory.sh
@@ -2,11 +2,18 @@
 # Sample a JVM's resident memory (and, best-effort, its used heap) at a fixed interval.
 #
 # This is the server-side half of the benchmark: k6 only sees client-side latency/throughput,
-# so memory-per-connection has to be measured here. RSS is the honest "total footprint" figure
-# (committed heap + thread stacks + Netty direct buffers + JVM overhead). jcmd GC.heap_info adds
-# the live-heap breakdown, which is where virtual-thread continuations live — so comparing RSS
-# growth against heap growth shows whether a target pays per connection in native stacks
-# (platform threads) or cheap on-heap continuations (virtual threads).
+# so memory-per-connection and CPU cost have to be measured here. RSS is the honest "total
+# footprint" figure (committed heap + thread stacks + Netty direct buffers + JVM overhead).
+# jcmd GC.heap_info adds the live-heap breakdown, which is where virtual-thread continuations
+# live — so comparing RSS growth against heap growth shows whether a target pays per connection
+# in native stacks (platform threads) or cheap on-heap continuations (virtual threads).
+#
+# cpu_cumulative is the process's total CPU time (all threads) so far, as reported by
+# `ps -o cputime` (e.g. "1:23.45" = MM:SS.ss, or "1:02:03" = HH:MM:SS). summarize.py differences
+# it across the load window to get average cores used — the discriminator for whether a
+# throughput win is structural (more requests per core) or just grabbing more cores on a
+# contended box. We record it cumulatively (not %cpu, which ps reports as a lifetime average
+# that would smear in idle + warmup) so the delta cleanly isolates the load window.
 #
 # Usage: sample-memory.sh <pid> <output_csv> [interval_seconds] [max_samples]
 set -euo pipefail
@@ -16,14 +23,16 @@ OUT="${2:?usage: sample-memory.sh <pid> <output_csv> [interval] [max_samples]}"
 INTERVAL="${3:-2}"
 MAX="${4:-100000}"
 
-echo "ts_epoch,rss_kb,heap_used_kb" > "$OUT"
+echo "ts_epoch,rss_kb,heap_used_kb,cpu_cumulative" > "$OUT"
 
 i=0
 while kill -0 "$PID" 2>/dev/null && [ "$i" -lt "$MAX" ]; do
   rss=$(ps -o rss= -p "$PID" 2>/dev/null | tr -d ' ' || true)
   # Best-effort heap parse; format varies by GC, so tolerate failure (blank column).
   heap=$(jcmd "$PID" GC.heap_info 2>/dev/null | sed -n 's/.*used \([0-9]*\)K.*/\1/p' | head -1 || true)
-  echo "$(date +%s),${rss:-},${heap:-}" >> "$OUT"
+  # Cumulative CPU time (all threads). No comma in the value, so it stays one CSV field.
+  cpu=$(ps -o cputime= -p "$PID" 2>/dev/null | tr -d ' ' || true)
+  echo "$(date +%s),${rss:-},${heap:-},${cpu:-}" >> "$OUT"
   i=$((i + 1))
   sleep "$INTERVAL"
 done

--- a/netty-loom-spring-benchmarks/scripts/summarize.py
+++ b/netty-loom-spring-benchmarks/scripts/summarize.py
@@ -7,7 +7,7 @@ Reads, per target:
   <name>_idle.csv           RSS samples taken before load
   <name>_high_load.csv      RSS samples taken during the high-concurrency run
 
-Usage: summarize.py <results_dir> <vus> <java_flags> <uname>
+Usage: summarize.py <results_dir> <vus> <java_flags> <uname> <tomcat_max_connections>
 """
 import json
 import os
@@ -19,6 +19,7 @@ RESULTS_DIR = sys.argv[1]
 VUS = int(sys.argv[2])
 JAVA_FLAGS = sys.argv[3]
 UNAME = sys.argv[4] if len(sys.argv) > 4 else "unknown"
+TOMCAT_MAXCONN = sys.argv[5] if len(sys.argv) > 5 else None
 
 TARGETS = [
     ("netty-loom", "Netty-Loom (this library)"),
@@ -89,6 +90,12 @@ out.append("")
 out.append(f"- **Date:** {date.today().isoformat()}")
 out.append(f"- **Machine:** `{UNAME}`")
 out.append(f"- **JVM flags (identical for all targets):** `{JAVA_FLAGS}`")
+if TOMCAT_MAXCONN:
+    out.append(f"- **Tomcat connector:** `max-connections={TOMCAT_MAXCONN}` on both Tomcat targets, "
+               f"and `threads.max={TOMCAT_MAXCONN}` on the virtual target (platform keeps the default "
+               "`threads.max=200` — the thread-per-request pool under test). Raised above the connection "
+               "count so Tomcat's default `max-connections=8192` accept ceiling — which "
+               "`spring.threads.virtual.enabled` does not touch — isn't the confound.")
 out.append(f"- **High-concurrency connections (VUs):** {VUS:,}")
 out.append("- **Workload:** `GET /work` → `Thread.sleep(50)` (simulated 50ms blocking DB call); "
            "keep-alive on, so 1 VU ≈ 1 connection ≈ 1 in-flight request.")

--- a/netty-loom-spring-benchmarks/scripts/summarize.py
+++ b/netty-loom-spring-benchmarks/scripts/summarize.py
@@ -20,6 +20,7 @@ VUS = int(sys.argv[2])
 JAVA_FLAGS = sys.argv[3]
 UNAME = sys.argv[4] if len(sys.argv) > 4 else "unknown"
 TOMCAT_MAXCONN = sys.argv[5] if len(sys.argv) > 5 else None
+NCORES = os.cpu_count() or 1
 
 TARGETS = [
     ("netty-loom", "Netty-Loom (this library)"),
@@ -72,6 +73,49 @@ def rss_kb(csv_name):
     return vals
 
 
+def parse_cputime(s):
+    """Parse `ps -o cputime` output ([DD-]HH:MM:SS[.ss] / MM:SS.ss) to seconds."""
+    s = s.strip()
+    if not s:
+        return None
+    days = 0
+    if "-" in s:
+        d, s = s.split("-", 1)
+        days = int(d)
+    try:
+        parts = [float(p) for p in s.split(":")]
+    except ValueError:
+        return None
+    while len(parts) < 3:
+        parts.insert(0, 0.0)
+    h, m, sec = parts
+    return days * 86400 + h * 3600 + m * 60 + sec
+
+
+def cpu_avg_cores(csv_name):
+    """Average cores used over the sampling window = Δ(cumulative CPU time) / Δ(wall clock).
+
+    Differencing first/last valid samples cancels CPU burned before the window (startup, JIT).
+    """
+    path = os.path.join(RESULTS_DIR, csv_name)
+    if not os.path.exists(path):
+        return None
+    samples = []
+    with open(path) as f:
+        next(f, None)
+        for line in f:
+            parts = line.strip().split(",")
+            if len(parts) >= 4 and parts[0].isdigit():
+                cpu = parse_cputime(parts[3])
+                if cpu is not None:
+                    samples.append((int(parts[0]), cpu))
+    if len(samples) < 2:
+        return None
+    wall = samples[-1][0] - samples[0][0]
+    cpu = samples[-1][1] - samples[0][1]
+    return (cpu / wall) if wall > 0 else None
+
+
 def f(v, nd=1, suffix=""):
     return "n/a" if v is None else f"{v:.{nd}f}{suffix}"
 
@@ -90,6 +134,7 @@ out.append("")
 out.append(f"- **Date:** {date.today().isoformat()}")
 out.append(f"- **Machine:** `{UNAME}`")
 out.append(f"- **JVM flags (identical for all targets):** `{JAVA_FLAGS}`")
+out.append(f"- **Logical cores:** {NCORES} (client and server share this box — see CPU efficiency below)")
 if TOMCAT_MAXCONN:
     out.append(f"- **Tomcat connector:** `max-connections={TOMCAT_MAXCONN}` on both Tomcat targets, "
                f"and `threads.max={TOMCAT_MAXCONN}` on the virtual target (platform keeps the default "
@@ -107,10 +152,14 @@ out.append("")
 # ---- Headline (derived from scenario 2 data) ----
 def high_stats(name):
     s = load_summary(name, "high")
+    thr = pick(metric(s, "http_reqs"), "rate")
+    cores = cpu_avg_cores(f"{name}_high_load.csv")
     return {
-        "thr": pick(metric(s, "http_reqs"), "rate"),
+        "thr": thr,
         "p99": pick(metric(s, "http_req_duration"), "p(99)"),
         "err": (pick(metric(s, "http_req_failed"), "value", "rate") or 0) * 100,
+        "cores": cores,
+        "per_core": (thr / cores) if (thr is not None and cores) else None,
     }
 
 
@@ -129,6 +178,10 @@ if all(v["thr"] is not None and v["p99"] is not None for v in (nl, tp, tv)):
                f"({tp['p99'] / nl['p99']:.1f}×).")
     out.append(f"- **Error rate:** Netty-Loom {nl['err']:.2f}% vs Tomcat+VT {tv['err']:.2f}% "
                f"vs Tomcat-platform {tp['err']:.2f}%.")
+    if nl["per_core"] and tv["per_core"]:
+        out.append(f"- **CPU efficiency:** Netty-Loom {nl['cores']:.1f} cores → "
+                   f"{nl['per_core']:,.0f} req/s per core vs Tomcat+VT {tv['cores']:.1f} cores → "
+                   f"{tv['per_core']:,.0f} req/s per core.")
     out.append("")
     beats_vt = nl["p99"] < tv["p99"] and nl["err"] <= tv["err"] and nl["thr"] >= tv["thr"]
     if beats_vt:
@@ -140,8 +193,24 @@ if all(v["thr"] is not None and v["p99"] is not None for v in (nl, tp, tv)):
                    "On this workload Tomcat+VT is competitive with Netty-Loom — read that honestly: "
                    "the cheaper recommendation may be to enable virtual threads on Tomcat.")
     out.append("")
+    if nl["per_core"] and tv["per_core"]:
+        if nl["per_core"] >= tv["per_core"]:
+            out.append("**Is the throughput edge structural or a single-box contention artifact?** "
+                       f"Structural: Netty-Loom does more work *per core* "
+                       f"({nl['per_core']:,.0f} vs {tv['per_core']:,.0f} req/s/core), so the win isn't "
+                       "merely from grabbing cores k6 left idle. Off-box, raw per-request efficiency may "
+                       "compress, but a per-core advantage like this should persist.")
+        else:
+            out.append("**Is the throughput edge structural or a single-box contention artifact?** "
+                       f"Partly contention: Netty-Loom's throughput/core ({nl['per_core']:,.0f}) is "
+                       f"*below* Tomcat+VT's ({tv['per_core']:,.0f}), so some of its raw throughput comes "
+                       "from pinning more cores on this contended box. The I/O-parallelism win should "
+                       "persist off-box, but the raw-efficiency component would compress — confirm on "
+                       "two hosts.")
+        out.append("")
     out.append("> Single-box loopback numbers: the k6 client contends with the server for CPU, so "
-               "absolute latencies are inflated and the comparison is relative, not absolute. See "
+               "absolute latencies are inflated and the comparison is relative, not absolute. The CPU "
+               "efficiency table is the discriminator for what survives off-box. See "
                "[README](../README.md) caveats.")
     out.append("")
 
@@ -168,6 +237,36 @@ def scenario_table(scenario, heading):
 
 scenario_table("low", "Scenario 1 — low-concurrency throughput (1→10 VUs, `GET /ping`)")
 scenario_table("high", f"Scenario 2 — high-concurrency blocking I/O ({VUS:,} VUs, `GET /work`)")
+
+# ---- CPU efficiency (the structural-win vs contention-artifact discriminator) ----
+out.append(f"## CPU efficiency (server-side, during the {VUS:,}-connection run)")
+out.append("")
+out.append(row(["Target", "Throughput (req/s)", "CPU (avg cores)", f"CPU util % (of {NCORES})",
+                "Throughput / core (req/s)"]))
+out.append(row(["---", "---:", "---:", "---:", "---:"]))
+for name, label in TARGETS:
+    s = load_summary(name, "high")
+    thr = pick(metric(s, "http_reqs"), "rate")
+    cores = cpu_avg_cores(f"{name}_high_load.csv")
+    util = (cores / NCORES * 100) if cores is not None else None
+    per_core = (thr / cores) if (thr is not None and cores) else None
+    out.append(row([
+        label,
+        f(thr, 0),
+        f(cores, 2),
+        f(util, 1, "%"),
+        f(per_core, 0),
+    ]))
+out.append("")
+out.append("Server-process CPU only (the k6 client is a separate process). **CPU (avg cores)** = "
+           "Δ(cumulative CPU time) / Δ(wall clock) over the load window, so it counts only CPU burned "
+           "while serving the load, not startup/JIT. **Throughput / core** is the discriminator: at "
+           f"{VUS:,} connections the client and server contend for the same {NCORES} cores, so raw "
+           "throughput partly reflects who grabbed more cores. Throughput-per-core is allocation-"
+           "independent — a higher value means more requests served per core of work, an efficiency "
+           "edge that should survive moving the client off-box. A target can post high throughput "
+           "simply by pinning more cores; only a higher throughput-per-core says the win is structural.")
+out.append("")
 
 # ---- Memory per connection ----
 out.append(f"## Memory per connection (under {VUS:,} concurrent connections)")

--- a/netty-loom-spring-example-tomcat/src/main/resources/application-platform.properties
+++ b/netty-loom-spring-example-tomcat/src/main/resources/application-platform.properties
@@ -1,3 +1,8 @@
 # Tomcat with the classic platform-thread pool (the thread-per-request baseline).
 server.port=18081
 spring.threads.virtual.enabled=false
+# Raise the accept ceiling above the benchmark's connection count so the default
+# maxConnections=8192 isn't the confound. threads.max stays at its default (200): the
+# bounded thread-per-request pool IS the architecture under test here. This standalone
+# default = 2 x the default VUS (10000); run-all.sh overrides it with 2 x the actual VUS.
+server.tomcat.max-connections=20000

--- a/netty-loom-spring-example-tomcat/src/main/resources/application-virtual.properties
+++ b/netty-loom-spring-example-tomcat/src/main/resources/application-virtual.properties
@@ -1,3 +1,11 @@
 # Tomcat dispatching each request onto a virtual thread (Loom-on-Tomcat).
 server.port=18082
 spring.threads.virtual.enabled=true
+# Raise the accept ceiling above the benchmark's connection count so the default
+# maxConnections=8192 isn't the confound. With virtual threads on, Tomcat replaces the
+# worker pool with a VirtualThreadExecutor, so threads.max no longer bounds processing —
+# we raise it anyway so no reviewer can claim the VT path was artificially throttled.
+# These standalone defaults = 2 x the default VUS (10000); run-all.sh overrides both
+# with 2 x the actual VUS.
+server.tomcat.max-connections=20000
+server.tomcat.threads.max=20000


### PR DESCRIPTION
Follow-up hardening of the k6 three-way benchmark (#9, merged in #33), addressing two reviewer critiques so the surviving gap can't be dismissed as an artifact.

## 1. Remove the accept-ceiling confound (`e9960d0`)
Tomcat's NIO connector defaults to `max-connections=8192`. Enabling virtual threads only swaps the request executor for a `VirtualThreadExecutor` — it does **not** touch the acceptor/poller/`max-connections` (verified in spring-boot-tomcat 4.0.5's `TomcatVirtualThreadsWebServerFactoryCustomizer`). So at 10k connections ~1,800 overflowed the default ceiling and were reset/queued — config masquerading as architecture.

`run-all.sh` now sets `max-connections=2×VUS` on both Tomcat targets (and `threads.max` to match on the virtual target, inert under the VT executor but forecloses the "you throttled the VT path" objection); the platform target keeps `threads.max=200` — the thread-per-request pool *is* the architecture under test.

**Result:** errors vanished (platform 4.68%→0%, virtual 1.15%→0%) — they were the accept-ceiling artifact — but the throughput (~3×) and p99 (~10×) gaps survived with zero errors everywhere.

## 2. Report per-target CPU efficiency (`29aa8fa`)
On a single box the k6 client and server share cores, so raw throughput partly reflects who grabbed more cores. The discriminator is **throughput-per-core** (allocation-independent): if the leaner pipeline serves more requests per core, the win survives off-box; if it only pins more cores, that part is a contention artifact.

`sample-memory.sh` now records cumulative CPU time (`ps -o cputime`); `summarize.py` differences it across the load window (cancelling startup/JIT) into average cores used, adds a **CPU efficiency** table, and emits a data-driven structural-vs-contention verdict.

**Result (confirmed across two 10k runs):** Netty-Loom serves **~22,900 req/s per core** vs Tomcat+VT's ~5,300–5,700 — a **~4× per-core efficiency edge while using fewer cores** (1.8 vs 2.2–2.6). The win is structural, not a single-box artifact.

## Headline (10k blocking connections, after both fixes)
| Metric | Netty-Loom | Tomcat+VT | Tomcat-platform |
|---|---|---|---|
| Throughput | ~42k req/s | ~13k | ~3.8k |
| p99 | ~450 ms | ~5,200 ms | ~2,700 ms |
| Error rate | 0.00% | 0.00% | 0.00% |
| Throughput/core | ~22,900 | ~5,300 | — |

Flipping `spring.threads.virtual.enabled=true` on Tomcat does **not** close the gap; the wedge is more than a config flag.

## Scope / notes
- Pure benchmark tooling + the two Tomcat example profiles — no library/app source changes; existing tests unaffected.
- Committed `results/SNAPSHOT.md` regenerated with real numbers; the pre-fix snapshot is in history (`c4f4270`) for before/after.
- Single-box loopback caveats and the two-host "gold" config remain documented in the README.