### PR TITLE
Auto-select native transport (epoll/kqueue) with NIO fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Run on both OSes so the auto-select logic and both native paths (epoll on Linux,
+    # kqueue on macOS) are actually exercised.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4

--- a/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/NettyLoomAutoConfiguration.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/NettyLoomAutoConfiguration.java
@@ -8,6 +8,7 @@ import io.github.azholdaspaev.nettyloomspring.core.handler.HttpRequestHandler;
 import io.github.azholdaspaev.nettyloomspring.core.pipeline.DefaultNettyPipelineConfigurer;
 import io.github.azholdaspaev.nettyloomspring.core.pipeline.NamedChannelHandler;
 import io.github.azholdaspaev.nettyloomspring.core.pipeline.NettyPipelineConfigurer;
+import io.github.azholdaspaev.nettyloomspring.core.server.NettyIoHandlerFactory;
 import io.github.azholdaspaev.nettyloomspring.core.server.NettyServer;
 import io.github.azholdaspaev.nettyloomspring.core.server.NettyServerChannelInitializer;
 import io.github.azholdaspaev.nettyloomspring.core.server.NettyServerConfiguration;
@@ -50,13 +51,25 @@ public class NettyLoomAutoConfiguration {
     }
 
     @Bean
-    public NettyServer nettyServer(NettyLoomProperties properties,
-                                   NettyServerChannelInitializer nettyServerChannelInitializer,
-                                   ChannelGroup nettyLoomChannelGroup) {
-        NettyServerConfiguration configuration = new NettyServerConfiguration(
-            properties.port(), properties.bossThreads(), properties.workerThreads(), properties.keepAlive()
+    public NettyServerConfiguration nettyServerConfiguration(NettyLoomProperties properties) {
+        return new NettyServerConfiguration(
+            properties.port(), properties.bossThreads(), properties.workerThreads(), properties.keepAlive(),
+            properties.transport()
         );
-        return new NettyServer(configuration, nettyServerChannelInitializer, nettyLoomChannelGroup);
+    }
+
+    @Bean
+    public NettyIoHandlerFactory nettyIoHandlerFactory(NettyServerConfiguration nettyServerConfiguration) {
+        return new NettyIoHandlerFactory(nettyServerConfiguration);
+    }
+
+    @Bean
+    public NettyServer nettyServer(NettyServerConfiguration nettyServerConfiguration,
+                                   NettyServerChannelInitializer nettyServerChannelInitializer,
+                                   NettyIoHandlerFactory nettyIoHandlerFactory,
+                                   ChannelGroup nettyLoomChannelGroup) {
+
+        return new NettyServer(nettyServerConfiguration, nettyServerChannelInitializer, nettyIoHandlerFactory, nettyLoomChannelGroup);
     }
 
     @Bean

--- a/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/properties/NettyLoomProperties.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/properties/NettyLoomProperties.java
@@ -12,5 +12,6 @@ public record NettyLoomProperties(
     @DefaultValue("0") int workerThreads,
     @DefaultValue("true") boolean keepAlive,
     @DefaultValue("30s") Duration shutdownGracePeriod,
-    @DefaultValue("30s") Duration readTimeout
+    @DefaultValue("30s") Duration readTimeout,
+    @DefaultValue("auto") String transport
 ) {}

--- a/netty-loom-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/netty-loom-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -25,9 +25,36 @@
     {
       "name": "server.netty.shutdown-grace-period",
       "description": "Maximum time to wait for in-flight HTTP requests to complete when Spring Boot invokes graceful shutdown (server.shutdown=graceful). After this deadline, remaining connections are force-closed. Defaults to 30 seconds, matching spring.lifecycle.timeout-per-shutdown-phase."
+    },
+    {
+      "name": "server.netty.transport",
+      "type": "java.lang.String",
+      "description": "Netty I/O transport to use. 'auto' picks the best native transport for the platform (epoll on Linux, kqueue on macOS/BSD) and falls back to NIO when none is available. 'nio' forces the portable Java NIO transport. 'epoll' or 'kqueue' force that native transport and fail fast at startup if it is not available on the platform.",
+      "defaultValue": "auto"
     }
   ],
   "hints": [
+    {
+      "name": "server.netty.transport",
+      "values": [
+        {
+          "value": "auto",
+          "description": "Auto-select the best native transport (epoll/kqueue), falling back to NIO."
+        },
+        {
+          "value": "nio",
+          "description": "Portable Java NIO transport. Works everywhere."
+        },
+        {
+          "value": "epoll",
+          "description": "Linux native transport. Fails fast if unavailable."
+        },
+        {
+          "value": "kqueue",
+          "description": "macOS/BSD native transport. Fails fast if unavailable."
+        }
+      ]
+    },
     {
       "name": "server.netty.port",
       "values": [

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/properties/NettyLoomPropertiesTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/properties/NettyLoomPropertiesTest.java
@@ -25,6 +25,20 @@ class NettyLoomPropertiesTest {
         assertEquals(Duration.ofSeconds(5), properties.readTimeout());
     }
 
+    @Test
+    void shouldDefaultTransportToAuto() {
+        NettyLoomProperties properties = bind(Map.of());
+
+        assertEquals("auto", properties.transport());
+    }
+
+    @Test
+    void shouldOverrideTransportFromConfiguration() {
+        NettyLoomProperties properties = bind(Map.of("server.netty.transport", "nio"));
+
+        assertEquals("nio", properties.transport());
+    }
+
     private static NettyLoomProperties bind(Map<String, Object> source) {
         return new Binder(new MapConfigurationPropertySource(source))
             .bindOrCreate("server.netty", NettyLoomProperties.class);

--- a/netty-loom-spring-core/build.gradle.kts
+++ b/netty-loom-spring-core/build.gradle.kts
@@ -7,6 +7,14 @@ dependencies {
     api(libs.netty.codec.http)
     api(libs.netty.handler)
 
+    implementation(libs.netty.transport.native.epoll)
+    implementation(libs.netty.transport.native.kqueue)
+
+    runtimeOnly(variantOf(libs.netty.transport.native.epoll) { classifier("linux-x86_64") })
+    runtimeOnly(variantOf(libs.netty.transport.native.epoll) { classifier("linux-aarch_64") })
+    runtimeOnly(variantOf(libs.netty.transport.native.kqueue) { classifier("osx-x86_64") })
+    runtimeOnly(variantOf(libs.netty.transport.native.kqueue) { classifier("osx-aarch_64") })
+
     implementation(libs.slf4j.api)
 
     testImplementation(libs.junit.jupiter)

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyIoHandlerFactory.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyIoHandlerFactory.java
@@ -1,0 +1,33 @@
+package io.github.azholdaspaev.nettyloomspring.core.server;
+
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.kqueue.KQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the configured transport preference ({@code auto|nio|epoll|kqueue}) to a concrete
+ * {@link NettyTransport} once at construction, probing {@link Epoll}/{@link KQueue} availability, and
+ * exposes the matching {@link IoHandlerFactory} and server channel class for {@link NettyServer}.
+ */
+public class NettyIoHandlerFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(NettyIoHandlerFactory.class);
+
+    private final NettyTransport transport;
+
+    public NettyIoHandlerFactory(NettyServerConfiguration configuration) {
+        this.transport = NettyTransport.resolve(configuration.transport(), Epoll.isAvailable(), KQueue.isAvailable());
+        log.info("Netty transport selected: {}", transport);
+    }
+
+    public IoHandlerFactory getIoHandlerFactory() {
+        return transport.newIoHandlerFactory();
+    }
+
+    public Class<? extends ServerChannel> getServerChannelClass() {
+        return transport.serverChannelClass();
+    }
+}

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServer.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServer.java
@@ -7,8 +7,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
-import io.netty.channel.nio.NioIoHandler;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.Future;
 
 import java.net.InetSocketAddress;
@@ -22,15 +20,18 @@ public class NettyServer {
 
     private final NettyServerConfiguration configuration;
     private final NettyServerChannelInitializer channelInitializer;
+    private final NettyIoHandlerFactory ioHandlerFactory;
     private final ChannelGroup channelGroup;
 
     private volatile RunningState state;
 
     public NettyServer(NettyServerConfiguration configuration,
                        NettyServerChannelInitializer channelInitializer,
+                       NettyIoHandlerFactory ioHandlerFactory,
                        ChannelGroup channelGroup) {
         this.configuration = configuration;
         this.channelInitializer = channelInitializer;
+        this.ioHandlerFactory = ioHandlerFactory;
         this.channelGroup = channelGroup;
     }
 
@@ -110,7 +111,7 @@ public class NettyServer {
     private Channel bind(EventLoopGroup boss, EventLoopGroup worker) throws InterruptedException {
         ServerBootstrap bootstrap = new ServerBootstrap()
             .group(boss, worker)
-            .channel(NioServerSocketChannel.class)
+            .channel(ioHandlerFactory.getServerChannelClass())
             .childHandler(channelInitializer)
             .option(ChannelOption.SO_BACKLOG, 128)
             .childOption(ChannelOption.SO_KEEPALIVE, configuration.keepAlive());
@@ -141,8 +142,8 @@ public class NettyServer {
         }
     }
 
-    private static EventLoopGroup newEventLoopGroup(int threads) {
-        return new MultiThreadIoEventLoopGroup(threads, NioIoHandler.newFactory());
+    private EventLoopGroup newEventLoopGroup(int threads) {
+        return new MultiThreadIoEventLoopGroup(threads, ioHandlerFactory.getIoHandlerFactory());
     }
 
     private InetSocketAddress resolvedAddress() {

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerConfiguration.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerConfiguration.java
@@ -4,5 +4,6 @@ public record NettyServerConfiguration(
     int port,
     int bossThreads,
     int workerThreads,
-    boolean keepAlive
+    boolean keepAlive,
+    String transport
 ) {}

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyTransport.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyTransport.java
@@ -1,0 +1,100 @@
+package io.github.azholdaspaev.nettyloomspring.core.server;
+
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.EpollIoHandler;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.kqueue.KQueueIoHandler;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+import java.util.Locale;
+
+/**
+ * The resolved Netty I/O transports. Each constant pairs the {@link IoHandlerFactory} for the event
+ * loop group with the matching {@link ServerChannel} type for the server bootstrap — the two must come
+ * from the same family or {@code bind()} fails.
+ *
+ * <p>{@code auto} (and the other configurable preferences) are inputs to {@link #resolve}; the enum
+ * itself only models the concrete transports that can actually run.
+ */
+enum NettyTransport {
+    NIO {
+        @Override
+        IoHandlerFactory newIoHandlerFactory() {
+            return NioIoHandler.newFactory();
+        }
+
+        @Override
+        Class<? extends ServerChannel> serverChannelClass() {
+            return NioServerSocketChannel.class;
+        }
+    },
+    EPOLL {
+        @Override
+        IoHandlerFactory newIoHandlerFactory() {
+            return EpollIoHandler.newFactory();
+        }
+
+        @Override
+        Class<? extends ServerChannel> serverChannelClass() {
+            return EpollServerSocketChannel.class;
+        }
+    },
+    KQUEUE {
+        @Override
+        IoHandlerFactory newIoHandlerFactory() {
+            return KQueueIoHandler.newFactory();
+        }
+
+        @Override
+        Class<? extends ServerChannel> serverChannelClass() {
+            return KQueueServerSocketChannel.class;
+        }
+    };
+
+    /**
+     * A fresh {@link IoHandlerFactory} for this transport. Called once per event loop group (boss and
+     * worker each get their own), so it intentionally returns a new factory on every call.
+     */
+    abstract IoHandlerFactory newIoHandlerFactory();
+
+    abstract Class<? extends ServerChannel> serverChannelClass();
+
+    /**
+     * Resolves the configured transport preference to a concrete transport.
+     *
+     * <ul>
+     *   <li>{@code auto} — epoll if available, else kqueue if available, else NIO.</li>
+     *   <li>{@code nio} — always NIO.</li>
+     *   <li>{@code epoll} / {@code kqueue} — that transport, or {@link IllegalStateException} if the
+     *       native library is not available on this platform (explicit requests fail fast rather than
+     *       silently degrading).</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException if {@code requested} is null or not one of the known values
+     */
+    static NettyTransport resolve(String requested, boolean epollAvailable, boolean kqueueAvailable) {
+        if (requested == null) {
+            throw new IllegalArgumentException("transport must be one of: auto, nio, epoll, kqueue");
+        }
+        return switch (requested.trim().toLowerCase(Locale.ROOT)) {
+            case "auto" -> epollAvailable ? EPOLL : kqueueAvailable ? KQUEUE : NIO;
+            case "nio" -> NIO;
+            case "epoll" -> requireAvailable(EPOLL, epollAvailable);
+            case "kqueue" -> requireAvailable(KQUEUE, kqueueAvailable);
+            default -> throw new IllegalArgumentException(
+                "Unknown transport '" + requested + "'. Valid values: auto, nio, epoll, kqueue");
+        };
+    }
+
+    private static NettyTransport requireAvailable(NettyTransport transport, boolean available) {
+        if (!available) {
+            throw new IllegalStateException(
+                transport.name().toLowerCase(Locale.ROOT)
+                    + " transport requested but not available on this platform");
+        }
+        return transport;
+    }
+}

--- a/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerTest.java
+++ b/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerTest.java
@@ -27,11 +27,12 @@ class NettyServerTest {
 
     @BeforeEach
     void setup() {
-        NettyServerConfiguration configuration = new NettyServerConfiguration(0, 0, 0, false);
+        NettyServerConfiguration configuration = new NettyServerConfiguration(0, 0, 0, false, "auto");
         NettyPipelineConfigurer pipelineConfigurer = new DefaultNettyPipelineConfigurer(List.of());
         ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
         NettyServerChannelInitializer channelInitializer = new NettyServerChannelInitializer(pipelineConfigurer, channelGroup);
-        nettyServer = new NettyServer(configuration, channelInitializer, channelGroup);
+        NettyIoHandlerFactory nettyIoHandlerFactory = new NettyIoHandlerFactory(configuration);
+        nettyServer = new NettyServer(configuration, channelInitializer, nettyIoHandlerFactory, channelGroup);
     }
 
     @AfterEach

--- a/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyTransportTest.java
+++ b/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyTransportTest.java
@@ -1,0 +1,109 @@
+package io.github.azholdaspaev.nettyloomspring.core.server;
+
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NettyTransportTest {
+
+    // --- Pure resolution logic (no mocks, no OS dependency) ---
+
+    @Test
+    void autoPrefersEpollWhenAvailable() {
+        assertEquals(NettyTransport.EPOLL, NettyTransport.resolve("auto", true, true));
+        assertEquals(NettyTransport.EPOLL, NettyTransport.resolve("auto", true, false));
+    }
+
+    @Test
+    void autoFallsBackToKqueueWhenOnlyKqueueAvailable() {
+        assertEquals(NettyTransport.KQUEUE, NettyTransport.resolve("auto", false, true));
+    }
+
+    @Test
+    void autoFallsBackToNioWhenNoNativeAvailable() {
+        assertEquals(NettyTransport.NIO, NettyTransport.resolve("auto", false, false));
+    }
+
+    @Test
+    void nioIsAlwaysSelectedRegardlessOfAvailability() {
+        assertEquals(NettyTransport.NIO, NettyTransport.resolve("nio", true, true));
+        assertEquals(NettyTransport.NIO, NettyTransport.resolve("nio", false, false));
+    }
+
+    @Test
+    void explicitEpollSelectedWhenAvailable() {
+        assertEquals(NettyTransport.EPOLL, NettyTransport.resolve("epoll", true, false));
+    }
+
+    @Test
+    void explicitKqueueSelectedWhenAvailable() {
+        assertEquals(NettyTransport.KQUEUE, NettyTransport.resolve("kqueue", false, true));
+    }
+
+    @Test
+    void explicitEpollFailsFastWhenUnavailable() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> NettyTransport.resolve("epoll", false, false));
+        assertTrue(ex.getMessage().contains("epoll"));
+    }
+
+    @Test
+    void explicitKqueueFailsFastWhenUnavailable() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> NettyTransport.resolve("kqueue", false, false));
+        assertTrue(ex.getMessage().contains("kqueue"));
+    }
+
+    @Test
+    void unknownTransportIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> NettyTransport.resolve("io_uring", true, true));
+    }
+
+    @Test
+    void nullTransportIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> NettyTransport.resolve(null, true, true));
+    }
+
+    @Test
+    void requestedValueIsCaseAndWhitespaceInsensitive() {
+        assertEquals(NettyTransport.NIO, NettyTransport.resolve("  NIO ", true, true));
+        assertEquals(NettyTransport.EPOLL, NettyTransport.resolve("Auto", true, false));
+    }
+
+    // --- Live native paths: prove the platform's classifier jar is actually on the classpath ---
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void selectsEpollOnLinux() {
+        assertTrue(Epoll.isAvailable(), "epoll native library must be on the classpath on Linux");
+        NettyIoHandlerFactory factory = new NettyIoHandlerFactory(configWith("auto"));
+        assertEquals(EpollServerSocketChannel.class, factory.getServerChannelClass());
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    void selectsKqueueOnMac() {
+        assertTrue(KQueue.isAvailable(), "kqueue native library must be on the classpath on macOS");
+        NettyIoHandlerFactory factory = new NettyIoHandlerFactory(configWith("auto"));
+        assertEquals(KQueueServerSocketChannel.class, factory.getServerChannelClass());
+    }
+
+    @Test
+    void nioFactorySelectsNioServerChannel() {
+        NettyIoHandlerFactory factory = new NettyIoHandlerFactory(configWith("nio"));
+        assertEquals(NioServerSocketChannel.class, factory.getServerChannelClass());
+    }
+
+    private static NettyServerConfiguration configWith(String transport) {
+        return new NettyServerConfiguration(0, 0, 0, false, transport);
+    }
+}


### PR DESCRIPTION
Closes #10.

## What

Replaces the hardcoded `NioServerSocketChannel` / `NioIoHandler` with a transport selected at startup, configurable via a new `server.netty.transport` property (`auto` | `nio` | `epoll` | `kqueue`, default `auto`).

- **`NettyTransport`** enum pairs each transport's `IoHandlerFactory` with its matching `ServerChannel` class (they must come from the same family or `bind()` fails), and exposes a **pure** `resolve(requested, epollAvailable, kqueueAvailable)`:
  - `auto` → epoll if available, else kqueue, else NIO
  - `nio` → always NIO
  - `epoll` / `kqueue` → that transport, or **fail fast** (`IllegalStateException`) if the native lib isn't available on this platform
- **`NettyIoHandlerFactory`** resolves once (probing `Epoll`/`KQueue`), logs the choice at INFO, and hands `NettyServer` both the event-loop factory and the server channel class.

## Configuration

- New `server.netty.transport` property + IDE metadata description/hints.
- `netty-loom-spring-core` build pulls the native **Java classes** transitively via the base deps and the platform **binaries** (`.so`/`.jnilib`) via `runtimeOnly` classifier variants (`linux-x86_64`, `linux-aarch_64`, `osx-x86_64`, `osx-aarch_64`). Without the classifier jars, `Epoll/KQueue.isAvailable()` is always false and `auto` silently degrades to NIO.
- **CI matrix** expanded to `[ubuntu-latest, macos-latest]` so both native paths (epoll on Linux, kqueue on macOS) are actually exercised — previously the kqueue path shipped untested.

## Tests

- `NettyTransportTest` — full `resolve()` truth table (no mocks; pure function) plus `@EnabledOnOs` live-native assertions proving the platform's classifier jar is on the classpath (epoll on Linux, kqueue on macOS) and the resolved server channel class matches.
- `NettyLoomPropertiesTest` — `transport` default (`auto`) + override binding.
- `NettyServerTest` updated to start a real server on `auto`, so the native channel bind is exercised end-to-end on each CI runner.

## Verification

`./gradlew build` green locally on macOS (kqueue selected + bound). Acceptance criteria from #10 (incl. the CI matrix addition from the RFC 0001 F1 comment) are covered.