### PR TITLE
Execute registered servlet Filters before DispatcherServlet (#12)

### DIFF
--- a/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/NettyLoomAutoConfiguration.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/NettyLoomAutoConfiguration.java
@@ -108,7 +108,8 @@ public class NettyLoomAutoConfiguration {
     }
 
     @Bean
-    public HttpRequestDispatcher httpRequestDispatcher(DispatcherServlet dispatcherServlet) {
-        return new SpringHttpRequestDispatcher(dispatcherServlet);
+    public HttpRequestDispatcher httpRequestDispatcher(DispatcherServlet dispatcherServlet,
+                                                       NettyServletContext servletContext) {
+        return new SpringHttpRequestDispatcher(dispatcherServlet, servletContext);
     }
 }

--- a/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/server/NettyWebServerFactory.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/server/NettyWebServerFactory.java
@@ -1,8 +1,10 @@
 package io.github.azholdaspaev.nettyloomspring.autoconfigure.server;
 
 import io.github.azholdaspaev.nettyloomspring.core.server.NettyServer;
+import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyFilterConfig;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyServletConfig;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyServletContext;
+import io.github.azholdaspaev.nettyloomspring.mvc.servlet.RegisteredFilter;
 import jakarta.servlet.ServletException;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.boot.web.server.WebServerException;
@@ -33,6 +35,7 @@ public class NettyWebServerFactory implements ServletWebServerFactory {
     @Override
     public WebServer getWebServer(ServletContextInitializer... initializers) {
         initializeServletContext(initializers);
+        initializeFilters();
         initializeDispatcherServlet();
         return new NettyWebServer(nettyServer, shutdownGracePeriod);
     }
@@ -43,6 +46,16 @@ public class NettyWebServerFactory implements ServletWebServerFactory {
                 initializer.onStartup(servletContext);
             } catch (ServletException e) {
                 throw new WebServerException("Failed to run servlet context initializer", e);
+            }
+        }
+    }
+
+    private void initializeFilters() {
+        for (RegisteredFilter registeredFilter : servletContext.getRegisteredFilters()) {
+            try {
+                registeredFilter.filter().init(new NettyFilterConfig(registeredFilter.name(), servletContext));
+            } catch (ServletException e) {
+                throw new WebServerException("Failed to initialize filter '" + registeredFilter.name() + "'", e);
             }
         }
     }

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/FilterChainIntegrationTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/FilterChainIntegrationTest.java
@@ -1,0 +1,95 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.filter;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestApplication;
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestFixtures.HeaderFilter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@AutoConfigureRestTestClient
+@SpringBootTest(
+    classes = FilterTestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class FilterChainIntegrationTest {
+
+    @Autowired
+    private RestTestClient restTestClient;
+
+    @Autowired
+    private HeaderFilter headerFilter;
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void runsFilterThatSetsResponseHeader() {
+        restTestClient.get().uri("/api/greeting")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().valueEquals("X-Filtered", "yes");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void shortCircuitingFilterReturns403AndControllerIsNotInvoked() {
+        restTestClient.get().uri("/secure/data")
+            .exchange()
+            .expectStatus().isForbidden()
+            .expectBody().isEmpty();
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void filterRunsOnlyOnMatchingUrlPattern() {
+        restTestClient.get().uri("/filtered/data")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().valueEquals("X-Scoped", "yes");
+
+        restTestClient.get().uri("/api/greeting")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().doesNotExist("X-Scoped");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void exactPatternMatchesAgainstQueryStrippedPath() {
+        // /api/greeting is an EXACT filter mapping; a query string must not defeat the match,
+        // proving the dispatcher matches on getRequestURI() (path only), not the raw URI.
+        restTestClient.get().uri("/api/greeting?msg=hi")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().valueEquals("X-Exact", "yes");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void filtersRunInOrderResolvedByOrderAnnotation() {
+        restTestClient.get().uri("/api/greeting")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().valueEquals("X-Order", "10", "20", "30");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void midChainExceptionIsCaughtByUpstreamErrorFilter() {
+        restTestClient.get().uri("/boom/data")
+            .exchange()
+            .expectStatus().is5xxServerError()
+            .expectHeader().valueEquals("X-Error-Handled", "yes");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void headerFilterIsInitialisedExactlyOnce() {
+        assertEquals(1, headerFilter.initCount());
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestApplication.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestApplication.java
@@ -1,0 +1,11 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Isolated test application for the filter-chain integration tests. Kept in its own package so
+ * its fixture filters do not bleed into the {@code smoke.app} component scan (and vice versa).
+ */
+@SpringBootApplication
+public class FilterTestApplication {
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestConfig.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestConfig.java
@@ -1,0 +1,78 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestFixtures.ErrorHandlingFilter;
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestFixtures.ForbiddenFilter;
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestFixtures.HeaderFilter;
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestFixtures.OrderFilter;
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestFixtures.SetHeaderFilter;
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app.FilterTestFixtures.ThrowingFilter;
+import jakarta.servlet.Filter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+public class FilterTestConfig {
+
+    @Bean
+    HeaderFilter headerFilter() {
+        return new HeaderFilter();
+    }
+
+    @Bean
+    FilterRegistrationBean<HeaderFilter> headerFilterRegistration(HeaderFilter headerFilter) {
+        return registration(headerFilter, 0, "/*");
+    }
+
+    // Declared deliberately OUT of @Order sequence (30, 10, 20) so the ordering test can only
+    // pass if @Order resolution actually sorts them — not by accident of bean declaration order.
+    @Bean
+    FilterRegistrationBean<OrderFilter> orderFilter30() {
+        return registration(new OrderFilter("30"), 30, "/*");
+    }
+
+    @Bean
+    FilterRegistrationBean<OrderFilter> orderFilter10() {
+        return registration(new OrderFilter("10"), 10, "/*");
+    }
+
+    @Bean
+    FilterRegistrationBean<OrderFilter> orderFilter20() {
+        return registration(new OrderFilter("20"), 20, "/*");
+    }
+
+    @Bean
+    FilterRegistrationBean<SetHeaderFilter> scopedFilter() {
+        return registration(new SetHeaderFilter("X-Scoped"), 5, "/filtered/*");
+    }
+
+    @Bean
+    FilterRegistrationBean<SetHeaderFilter> exactFilter() {
+        return registration(new SetHeaderFilter("X-Exact"), 5, "/api/greeting");
+    }
+
+    @Bean
+    FilterRegistrationBean<ForbiddenFilter> forbiddenFilter() {
+        return registration(new ForbiddenFilter(), 5, "/secure/*");
+    }
+
+    // Throwing filter declared BEFORE its error handler so the "upstream catches downstream" test
+    // depends on @Order (HIGHEST_PRECEDENCE sorts first), not on declaration order.
+    @Bean
+    FilterRegistrationBean<ThrowingFilter> throwingFilter() {
+        return registration(new ThrowingFilter(), 100, "/boom/*");
+    }
+
+    @Bean
+    FilterRegistrationBean<ErrorHandlingFilter> errorHandlingFilter() {
+        return registration(new ErrorHandlingFilter(), Ordered.HIGHEST_PRECEDENCE, "/boom/*");
+    }
+
+    private static <T extends Filter> FilterRegistrationBean<T> registration(T filter, int order, String urlPattern) {
+        var registration = new FilterRegistrationBean<>(filter);
+        registration.addUrlPatterns(urlPattern);
+        registration.setOrder(order);
+        return registration;
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestController.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestController.java
@@ -1,0 +1,28 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FilterTestController {
+
+    @GetMapping("/api/greeting")
+    public String greeting() {
+        return "hello";
+    }
+
+    @GetMapping("/filtered/data")
+    public String filtered() {
+        return "filtered";
+    }
+
+    @GetMapping("/secure/data")
+    public String secure() {
+        return "secret";
+    }
+
+    @GetMapping("/boom/data")
+    public String boom() {
+        return "boom-reached";
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestFixtures.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/filter/app/FilterTestFixtures.java
@@ -1,0 +1,119 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.filter.app;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Filter implementations used by the filter-chain integration tests. Each models one acceptance
+ * criterion. Destructive filters (403, throwing) are scoped to dedicated URL patterns by
+ * {@link FilterTestConfig} so they never interfere with the all-paths fixtures.
+ */
+public final class FilterTestFixtures {
+
+    private FilterTestFixtures() {
+    }
+
+    /** Sets {@code X-Filtered: yes} on every response and counts how often it is initialised. */
+    public static final class HeaderFilter implements Filter {
+
+        private final AtomicInteger initCount = new AtomicInteger();
+
+        @Override
+        public void init(FilterConfig filterConfig) {
+            initCount.incrementAndGet();
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+            ((HttpServletResponse) response).setHeader("X-Filtered", "yes");
+            chain.doFilter(request, response);
+        }
+
+        public int initCount() {
+            return initCount.get();
+        }
+    }
+
+    /** Appends its token to the {@code X-Order} header, so invocation order is observable. */
+    static final class OrderFilter implements Filter {
+
+        private final String token;
+
+        OrderFilter(String token) {
+            this.token = token;
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+            ((HttpServletResponse) response).addHeader("X-Order", token);
+            chain.doFilter(request, response);
+        }
+    }
+
+    /**
+     * Sets a fixed response header then proceeds. Used both to mark a scoped path
+     * ({@code X-Scoped}) and to prove exact/query-stripped matching ({@code X-Exact} on
+     * {@code /api/greeting}, which must still match a request to {@code /api/greeting?x=1}).
+     */
+    static final class SetHeaderFilter implements Filter {
+
+        private final String headerName;
+
+        SetHeaderFilter(String headerName) {
+            this.headerName = headerName;
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+            ((HttpServletResponse) response).setHeader(headerName, "yes");
+            chain.doFilter(request, response);
+        }
+    }
+
+    /** Short-circuits with 403 and never proceeds, so the controller is not invoked. */
+    static final class ForbiddenFilter implements Filter {
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException {
+            ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
+        }
+    }
+
+    /** Upstream error filter: catches anything thrown downstream and converts it to a 500. */
+    static final class ErrorHandlingFilter implements Filter {
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+            try {
+                chain.doFilter(request, response);
+            } catch (Exception e) {
+                HttpServletResponse httpResponse = (HttpServletResponse) response;
+                httpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                httpResponse.setHeader("X-Error-Handled", "yes");
+            }
+        }
+    }
+
+    /** Throws mid-chain, to be caught by an upstream {@link ErrorHandlingFilter}. */
+    static final class ThrowingFilter implements Filter {
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws ServletException {
+            throw new ServletException("mid-chain failure");
+        }
+    }
+}

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/handler/SpringHttpRequestDispatcher.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/handler/SpringHttpRequestDispatcher.java
@@ -1,18 +1,28 @@
 package io.github.azholdaspaev.nettyloomspring.mvc.handler;
 
 import io.github.azholdaspaev.nettyloomspring.core.handler.HttpRequestDispatcher;
+import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyFilterChain;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyHttpServletRequest;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyHttpServletResponse;
+import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyServletContext;
+import io.github.azholdaspaev.nettyloomspring.mvc.servlet.RegisteredFilter;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import jakarta.servlet.FilterChain;
 import org.springframework.web.servlet.DispatcherServlet;
+
+import java.util.List;
 
 public class SpringHttpRequestDispatcher implements HttpRequestDispatcher {
 
-    private final DispatcherServlet dispatcherServlet;
+    private final NettyServletContext servletContext;
+    private final FilterChain terminal;
 
-    public SpringHttpRequestDispatcher(DispatcherServlet dispatcherServlet) {
-        this.dispatcherServlet = dispatcherServlet;
+    public SpringHttpRequestDispatcher(DispatcherServlet dispatcherServlet, NettyServletContext servletContext) {
+        this.servletContext = servletContext;
+        // The chain terminal hands the request to the DispatcherServlet; bound once here rather
+        // than re-creating the method reference per request.
+        this.terminal = dispatcherServlet::service;
     }
 
     @Override
@@ -20,7 +30,13 @@ public class SpringHttpRequestDispatcher implements HttpRequestDispatcher {
         NettyHttpServletRequest servletRequest = new NettyHttpServletRequest(request);
         NettyHttpServletResponse servletResponse = new NettyHttpServletResponse();
 
-        dispatcherServlet.service(servletRequest, servletResponse);
+        String requestPath = servletRequest.getRequestURI();
+        List<RegisteredFilter> applicable = servletContext.getRegisteredFilters().stream()
+            .filter(filter -> filter.matches(requestPath, servletRequest.getDispatcherType()))
+            .toList();
+
+        NettyFilterChain chain = new NettyFilterChain(applicable, terminal);
+        chain.doFilter(servletRequest, servletResponse);
 
         return servletResponse.toFullHttpResponse();
     }

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/DefaultNettyServletContext.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/DefaultNettyServletContext.java
@@ -1,5 +1,6 @@
 package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterRegistration;
 import jakarta.servlet.Servlet;
@@ -10,12 +11,15 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +33,11 @@ public class DefaultNettyServletContext implements NettyServletContext {
     private final ConcurrentMap<String, String> initParameters = new ConcurrentHashMap<>();
     private final Map<String, ServletRegistration> servletRegistrations = new LinkedHashMap<>();
     private final Map<String, FilterRegistration> filterRegistrations = new LinkedHashMap<>();
+    // Immutable snapshot of the executable filters, built once and reused on the per-request hot
+    // path. Invalidated (set to null) whenever a filter is registered, so a late registration
+    // rebuilds it on next read. Registration is single-threaded at startup; reads happen after
+    // server start, so the volatile field is sufficient for safe publication.
+    private volatile List<RegisteredFilter> registeredFiltersSnapshot;
 
     @Override
     public Object getAttribute(String name) {
@@ -100,25 +109,26 @@ public class DefaultNettyServletContext implements NettyServletContext {
         return Collections.unmodifiableMap(servletRegistrations);
     }
 
-    private FilterRegistration.Dynamic registerFilter(String filterName, String className) {
-        var registration = new NettyFilterRegistration(filterName, className);
+    private FilterRegistration.Dynamic registerFilter(String filterName, String className, Filter filter) {
+        var registration = new NettyFilterRegistration(filterName, className, filter);
         filterRegistrations.put(filterName, registration);
+        registeredFiltersSnapshot = null;
         return registration;
     }
 
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, String className) {
-        return registerFilter(filterName, className);
+        return registerFilter(filterName, className, null);
     }
 
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Filter filter) {
-        return registerFilter(filterName, filter.getClass().getName());
+        return registerFilter(filterName, filter.getClass().getName(), filter);
     }
 
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
-        return registerFilter(filterName, filterClass.getName());
+        return registerFilter(filterName, filterClass.getName(), null);
     }
 
     @Override
@@ -129,6 +139,26 @@ public class DefaultNettyServletContext implements NettyServletContext {
     @Override
     public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
         return Collections.unmodifiableMap(filterRegistrations);
+    }
+
+    @Override
+    public List<RegisteredFilter> getRegisteredFilters() {
+        List<RegisteredFilter> snapshot = registeredFiltersSnapshot;
+        if (snapshot == null) {
+            snapshot = buildRegisteredFilters();
+            registeredFiltersSnapshot = snapshot;
+        }
+        return snapshot;
+    }
+
+    private List<RegisteredFilter> buildRegisteredFilters() {
+        var registered = new ArrayList<RegisteredFilter>();
+        for (var registration : filterRegistrations.values()) {
+            if (registration instanceof NettyFilterRegistration filterRegistration && filterRegistration.filter != null) {
+                registered.add(filterRegistration.toRegisteredFilter());
+            }
+        }
+        return Collections.unmodifiableList(registered);
     }
 
     @Override
@@ -292,13 +322,24 @@ public class DefaultNettyServletContext implements NettyServletContext {
 
     private static class NettyFilterRegistration extends AbstractNettyRegistration implements FilterRegistration.Dynamic {
 
-        NettyFilterRegistration(String name, String className) {
+        private final Filter filter;
+        private final Set<String> urlPatterns = new LinkedHashSet<>();
+        private final EnumSet<DispatcherType> dispatcherTypes = EnumSet.noneOf(DispatcherType.class);
+
+        NettyFilterRegistration(String name, String className, Filter filter) {
             super(name, className);
+            this.filter = filter;
         }
 
         @Override
-        public void addMappingForServletNames(java.util.EnumSet<jakarta.servlet.DispatcherType> dispatcherTypes,
+        public void addMappingForServletNames(EnumSet<DispatcherType> dispatcherTypes,
                                                boolean isMatchAfter, String... servletNames) {
+            // Servlet-name filter mappings are not executed by this server (only URL-pattern
+            // mappings are). Warn so the unsupported mapping is observable instead of a silent no-op.
+            if (servletNames != null && servletNames.length > 0) {
+                log.warn("Filter '{}' declares servlet-name mappings {} which are not supported "
+                    + "and will be ignored; map it by URL pattern instead.", getName(), List.of(servletNames));
+            }
         }
 
         @Override
@@ -307,13 +348,24 @@ public class DefaultNettyServletContext implements NettyServletContext {
         }
 
         @Override
-        public void addMappingForUrlPatterns(java.util.EnumSet<jakarta.servlet.DispatcherType> dispatcherTypes,
+        public void addMappingForUrlPatterns(EnumSet<DispatcherType> dispatcherTypes,
                                               boolean isMatchAfter, String... urlPatterns) {
+            // The servlet spec defaults to REQUEST when no dispatcher types are supplied; Spring
+            // Boot always passes EnumSet.of(REQUEST), but the spec allows null.
+            this.dispatcherTypes.addAll(dispatcherTypes == null ? EnumSet.of(DispatcherType.REQUEST) : dispatcherTypes);
+            Collections.addAll(this.urlPatterns, urlPatterns);
         }
 
         @Override
         public Collection<String> getUrlPatternMappings() {
-            return Collections.emptySet();
+            return Collections.unmodifiableSet(urlPatterns);
+        }
+
+        RegisteredFilter toRegisteredFilter() {
+            // EnumSet.copyOf(EnumSet) handles the empty case; an unmapped filter has no URL
+            // patterns either, so it never matches regardless of dispatcher types.
+            return new RegisteredFilter(getName(), filter, new LinkedHashSet<>(urlPatterns),
+                EnumSet.copyOf(dispatcherTypes));
         }
     }
 }

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterChain.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterChain.java
@@ -1,0 +1,41 @@
+package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A {@link FilterChain} over an ordered list of applicable filters that terminates by invoking
+ * a terminal {@link FilterChain} (typically {@code DispatcherServlet::service}). One instance
+ * per request — the cursor is stateful, so it must not be shared across threads.
+ *
+ * <p>Each {@link #doFilter(ServletRequest, ServletResponse)} hands the request/response it
+ * <em>receives</em> to the next filter and to the terminal, so request/response wrappers
+ * installed by a filter propagate downstream. A filter that does not call {@code doFilter}
+ * short-circuits the chain: the terminal never runs and the controller is never invoked.
+ */
+public class NettyFilterChain implements FilterChain {
+
+    private final List<RegisteredFilter> filters;
+    private final FilterChain terminal;
+    private int index;
+
+    public NettyFilterChain(List<RegisteredFilter> filters, FilterChain terminal) {
+        this.filters = filters;
+        this.terminal = terminal;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+        if (index < filters.size()) {
+            RegisteredFilter current = filters.get(index++);
+            current.filter().doFilter(request, response, this);
+        } else {
+            terminal.doFilter(request, response);
+        }
+    }
+}

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterConfig.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterConfig.java
@@ -1,0 +1,42 @@
+package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
+
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
+
+import java.util.Collections;
+import java.util.Enumeration;
+
+/**
+ * Minimal {@link FilterConfig} passed to {@code Filter#init} at startup. Mirror of
+ * {@link NettyServletConfig}.
+ */
+public class NettyFilterConfig implements FilterConfig {
+
+    private final String filterName;
+    private final NettyServletContext servletContext;
+
+    public NettyFilterConfig(String filterName, NettyServletContext servletContext) {
+        this.filterName = filterName;
+        this.servletContext = servletContext;
+    }
+
+    @Override
+    public String getFilterName() {
+        return filterName;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return servletContext;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        return Collections.emptyEnumeration();
+    }
+}

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
@@ -485,7 +485,7 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public DispatcherType getDispatcherType() {
-        return null;
+        return DispatcherType.REQUEST;
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponse.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponse.java
@@ -56,12 +56,23 @@ public class NettyHttpServletResponse implements HttpServletResponse {
 
     @Override
     public void sendError(int sc, String msg) throws IOException {
+        discardBody();
         this.status = sc;
     }
 
     @Override
     public void sendError(int sc) throws IOException {
+        discardBody();
         this.status = sc;
+    }
+
+    private void discardBody() {
+        // Per the Servlet spec, sendError clears the response buffer (but not other headers/status).
+        resetBuffer();
+        // The body is now empty, so a previously-set Content-Length would mis-frame the response
+        // (client hangs waiting for bytes that never arrive); drop it and let toFullHttpResponse
+        // recompute Content-Length: 0.
+        headers.remove(HttpHeaders.CONTENT_LENGTH);
     }
 
     @Override
@@ -219,6 +230,10 @@ public class NettyHttpServletResponse implements HttpServletResponse {
     @Override
     public void resetBuffer() {
         body.reset();
+        // Drop the cached writer/stream too: the writer (autoFlush=false) holds an encoder buffer
+        // whose unflushed chars would otherwise be re-flushed into the body by toFullHttpResponse().
+        writer = null;
+        outputStream = null;
     }
 
     @Override
@@ -228,12 +243,10 @@ public class NettyHttpServletResponse implements HttpServletResponse {
 
     @Override
     public void reset() {
-        body.reset();
+        resetBuffer();
         headers.clear();
         status = HttpServletResponse.SC_OK;
         characterEncoding = StandardCharsets.ISO_8859_1;
-        writer = null;
-        outputStream = null;
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyServletContext.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyServletContext.java
@@ -16,10 +16,20 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.EventListener;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public interface NettyServletContext extends ServletContext {
+
+    /**
+     * Returns the executable filter registrations (those backed by a live {@link Filter}
+     * instance) in registration order, which already reflects Spring Boot's {@code @Order}
+     * resolution. Not part of the Jakarta {@link ServletContext} contract.
+     */
+    default List<RegisteredFilter> getRegisteredFilters() {
+        return List.of();
+    }
 
     @Override
     default String getContextPath() {

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/RegisteredFilter.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/RegisteredFilter.java
@@ -1,0 +1,57 @@
+package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * An executable filter registration: the live {@link Filter} instance together with the
+ * URL patterns and dispatcher types it was mapped to. Produced by
+ * {@link NettyServletContext#getRegisteredFilters()} and consumed by {@link NettyFilterChain}.
+ *
+ * <p>Matching is servlet-spec URL-pattern matching (Servlet 6, §12.2), not Ant matching.
+ */
+public record RegisteredFilter(String name, Filter filter, Set<String> urlPatterns,
+                               EnumSet<DispatcherType> dispatcherTypes) {
+
+    /**
+     * Returns {@code true} if this filter applies to a {@code dispatchType} dispatch of
+     * {@code requestPath} — i.e. the filter is mapped for that dispatcher type and one of its
+     * URL patterns matches the path.
+     */
+    public boolean matches(String requestPath, DispatcherType dispatchType) {
+        if (!dispatcherTypes.contains(dispatchType)) {
+            return false;
+        }
+        for (String pattern : urlPatterns) {
+            if (patternMatches(pattern, requestPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean patternMatches(String pattern, String path) {
+        if (pattern == null || pattern.isEmpty()) {
+            return false;
+        }
+        // Match-all.
+        if (pattern.equals("/*")) {
+            return true;
+        }
+        // Path-prefix mapping: "/p/*" matches "/p", "/p/", and "/p/...", but not "/px".
+        if (pattern.endsWith("/*")) {
+            String prefix = pattern.substring(0, pattern.length() - 2);
+            return path.equals(prefix) || path.startsWith(prefix + "/");
+        }
+        // Extension mapping: "*.ext" (a bare "*." has no extension and matches nothing).
+        if (pattern.startsWith("*.") && pattern.length() > 2) {
+            String extension = pattern.substring(1); // ".ext"
+            return path.endsWith(extension);
+        }
+        // Exact mapping.
+        return pattern.equals(path);
+    }
+}

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/DefaultNettyServletContextTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/DefaultNettyServletContextTest.java
@@ -1,5 +1,6 @@
 package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterRegistration;
 import jakarta.servlet.Servlet;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
+import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
@@ -410,6 +412,63 @@ class DefaultNettyServletContextTest {
         var registration = context.addFilter("f", "com.example.F");
 
         assertTrue(registration.getUrlPatternMappings().isEmpty());
+    }
+
+    @Test
+    void shouldStoreUrlPatternMappings() {
+        var registration = context.addFilter("f", new StubFilter());
+
+        registration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "/api/*", "/admin/*");
+
+        assertTrue(registration.getUrlPatternMappings().containsAll(List.of("/api/*", "/admin/*")));
+    }
+
+    @Test
+    void shouldDefaultDispatcherTypesToRequestWhenNullPassed() {
+        var registration = context.addFilter("f", new StubFilter());
+
+        registration.addMappingForUrlPatterns(null, false, "/*");
+
+        var registered = context.getRegisteredFilters();
+        assertEquals(1, registered.size());
+        assertTrue(registered.get(0).dispatcherTypes().contains(DispatcherType.REQUEST));
+    }
+
+    // --- Executable filter registrations (getRegisteredFilters) ---
+
+    @Test
+    void shouldRetainFilterInstanceInRegisteredFilters() {
+        Filter filter = new StubFilter();
+        var registration = context.addFilter("myFilter", filter);
+        registration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "/*");
+
+        var registered = context.getRegisteredFilters();
+
+        assertEquals(1, registered.size());
+        assertEquals("myFilter", registered.get(0).name());
+        assertEquals(filter, registered.get(0).filter());
+    }
+
+    @Test
+    void shouldPreserveRegistrationOrderInRegisteredFilters() {
+        context.addFilter("first", new StubFilter());
+        context.addFilter("second", new StubFilter());
+
+        var registered = context.getRegisteredFilters();
+
+        assertEquals(List.of("first", "second"), registered.stream().map(RegisteredFilter::name).toList());
+    }
+
+    @Test
+    void shouldExcludeClassNameOnlyRegistrationsFromRegisteredFilters() {
+        context.addFilter("instanceFilter", new StubFilter());
+        context.addFilter("classNameFilter", "com.example.MyFilter");
+        context.addFilter("classFilter", StubFilter.class);
+
+        var registered = context.getRegisteredFilters();
+
+        assertEquals(1, registered.size());
+        assertEquals("instanceFilter", registered.get(0).name());
     }
 
     // --- Resource methods (all return null) ---

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterChainTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterChainTest.java
@@ -1,0 +1,131 @@
+package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NettyFilterChainTest {
+
+    private final List<String> trace = new ArrayList<>();
+
+    private RegisteredFilter recording(String name) {
+        Filter filter = (request, response, chain) -> {
+            trace.add("enter:" + name);
+            chain.doFilter(request, response);
+            trace.add("exit:" + name);
+        };
+        return new RegisteredFilter(name, filter, Set.of("/*"), EnumSet.of(DispatcherType.REQUEST));
+    }
+
+    private RegisteredFilter shortCircuiting(String name) {
+        Filter filter = (request, response, chain) -> trace.add("short:" + name);
+        return new RegisteredFilter(name, filter, Set.of("/*"), EnumSet.of(DispatcherType.REQUEST));
+    }
+
+    private FilterChain terminal() {
+        return (request, response) -> trace.add("terminal");
+    }
+
+    @Test
+    void runsFiltersInOrderThenTerminalOnce() throws Exception {
+        var chain = new NettyFilterChain(List.of(recording("a"), recording("b")), terminal());
+
+        chain.doFilter(null, null);
+
+        assertEquals(List.of("enter:a", "enter:b", "terminal", "exit:b", "exit:a"), trace);
+        assertEquals(1, trace.stream().filter("terminal"::equals).count());
+    }
+
+    @Test
+    void runsTerminalImmediatelyWhenNoFilters() throws Exception {
+        var chain = new NettyFilterChain(List.of(), terminal());
+
+        chain.doFilter(null, null);
+
+        assertEquals(List.of("terminal"), trace);
+    }
+
+    @Test
+    void shortCircuitsWhenFilterDoesNotProceed() throws Exception {
+        var chain = new NettyFilterChain(List.of(shortCircuiting("a"), recording("b")), terminal());
+
+        chain.doFilter(null, null);
+
+        assertEquals(List.of("short:a"), trace);
+        assertTrue(trace.stream().noneMatch("terminal"::equals));
+    }
+
+    @Test
+    void propagatesExceptionFromFilter() {
+        Filter boom = (request, response, chain) -> {
+            throw new ServletException("boom");
+        };
+        var chain = new NettyFilterChain(
+            List.of(new RegisteredFilter("boom", boom, Set.of("/*"), EnumSet.of(DispatcherType.REQUEST))),
+            terminal());
+
+        assertThrows(ServletException.class, () -> chain.doFilter(null, null));
+        assertTrue(trace.stream().noneMatch("terminal"::equals));
+    }
+
+    @Test
+    void propagatesRequestAndResponseWrappersToDownstreamFilterAndTerminal() throws Exception {
+        var original = new NettyHttpServletRequest(
+            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/x"));
+        var wrappedRequest = new HttpServletRequestWrapper(original);
+        var wrappedResponse = new HttpServletResponseWrapper(new NettyHttpServletResponse());
+
+        Filter wrapping = (request, response, chain) -> chain.doFilter(wrappedRequest, wrappedResponse);
+        var downstreamRequest = new ServletRequest[1];
+        var downstreamResponse = new ServletResponse[1];
+        Filter downstream = (request, response, chain) -> {
+            downstreamRequest[0] = request;
+            downstreamResponse[0] = response;
+            chain.doFilter(request, response);
+        };
+        var terminalRequest = new ServletRequest[1];
+        FilterChain terminal = (request, response) -> terminalRequest[0] = request;
+
+        var chain = new NettyFilterChain(
+            List.of(
+                new RegisteredFilter("wrap", wrapping, Set.of("/*"), EnumSet.of(DispatcherType.REQUEST)),
+                new RegisteredFilter("down", downstream, Set.of("/*"), EnumSet.of(DispatcherType.REQUEST))),
+            terminal);
+
+        chain.doFilter(original, new NettyHttpServletResponse());
+
+        assertSame(wrappedRequest, downstreamRequest[0]);
+        assertSame(wrappedResponse, downstreamResponse[0]);
+        assertSame(wrappedRequest, terminalRequest[0]);
+    }
+
+    @Test
+    void terminalCanThrowCheckedException() {
+        FilterChain throwing = (request, response) -> {
+            throw new IOException("io");
+        };
+        var chain = new NettyFilterChain(List.of(), throwing);
+
+        assertThrows(IOException.class, () -> chain.doFilter(null, null));
+    }
+}

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponseTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponseTest.java
@@ -1,0 +1,53 @@
+package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NettyHttpServletResponseTest {
+
+    @Test
+    void sendErrorDiscardsAnyPreviouslyWrittenBody() throws Exception {
+        var response = new NettyHttpServletResponse();
+        response.getWriter().write("partial output written before the error");
+
+        response.sendError(HttpResponseStatus.FORBIDDEN.code());
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertEquals(HttpResponseStatus.FORBIDDEN.code(), httpResponse.status().code());
+        assertEquals("", httpResponse.content().toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void sendErrorClearsStaleContentLengthHeader() throws Exception {
+        var response = new NettyHttpServletResponse();
+        response.setContentLength(100);
+        response.getWriter().write("a body that will be discarded by sendError");
+
+        response.sendError(HttpResponseStatus.FORBIDDEN.code());
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        // Empty body must not be advertised with the stale Content-Length: 100, which would
+        // make the client hang waiting for bytes that never arrive.
+        assertEquals(0, httpResponse.content().readableBytes());
+        assertEquals("0", httpResponse.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+    }
+
+    @Test
+    void resetBufferDiscardsContentBufferedInTheWriter() throws Exception {
+        var response = new NettyHttpServletResponse();
+        // Writer uses autoFlush=false, so these chars sit in the writer's encoder buffer,
+        // not yet flushed to the body — resetBuffer() must discard them, not just body's bytes.
+        response.getWriter().write("buffered but not yet flushed to the body");
+
+        response.resetBuffer();
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertEquals(0, httpResponse.content().readableBytes());
+    }
+}

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/RegisteredFilterTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/RegisteredFilterTest.java
@@ -1,0 +1,87 @@
+package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RegisteredFilterTest {
+
+    private static RegisteredFilter filterFor(Set<String> patterns, EnumSet<DispatcherType> dispatcherTypes) {
+        Filter noop = (request, response, chain) -> chain.doFilter(request, response);
+        return new RegisteredFilter("f", noop, patterns, dispatcherTypes);
+    }
+
+    private static RegisteredFilter requestFilter(String... patterns) {
+        return filterFor(new LinkedHashSet<>(Set.of(patterns)), EnumSet.of(DispatcherType.REQUEST));
+    }
+
+    private static boolean matchesAsRequest(RegisteredFilter filter, String path) {
+        return filter.matches(path, DispatcherType.REQUEST);
+    }
+
+    @Test
+    void exactPatternMatchesOnlyExactPath() {
+        var filter = requestFilter("/foo");
+
+        assertTrue(matchesAsRequest(filter,"/foo"));
+        assertFalse(matchesAsRequest(filter,"/foo/bar"));
+        assertFalse(matchesAsRequest(filter,"/foobar"));
+    }
+
+    @Test
+    void extensionPatternMatchesBySuffix() {
+        var filter = requestFilter("*.json");
+
+        assertTrue(matchesAsRequest(filter,"/api/data.json"));
+        assertFalse(matchesAsRequest(filter,"/api/data.xml"));
+    }
+
+    @Test
+    void wildcardPatternMatchesEverything() {
+        var filter = requestFilter("/*");
+
+        assertTrue(matchesAsRequest(filter,"/"));
+        assertTrue(matchesAsRequest(filter,"/anything/at/all"));
+    }
+
+    @Test
+    void pathPrefixMatchesBarePrefixAndDescendantsButNotSiblingPrefix() {
+        var filter = requestFilter("/api/*");
+
+        assertTrue(matchesAsRequest(filter,"/api"));
+        assertTrue(matchesAsRequest(filter,"/api/"));
+        assertTrue(matchesAsRequest(filter,"/api/users"));
+        assertFalse(matchesAsRequest(filter,"/apix"));
+        assertFalse(matchesAsRequest(filter,"/other"));
+    }
+
+    @Test
+    void degenerateExtensionPatternMatchesNothing() {
+        var filter = requestFilter("*.");
+
+        assertFalse(matchesAsRequest(filter,"/file."));
+        assertFalse(matchesAsRequest(filter,"/file.json"));
+    }
+
+    @Test
+    void multiplePatternsMatchIfAnyMatches() {
+        var filter = requestFilter("/never", "/api/*");
+
+        assertTrue(matchesAsRequest(filter,"/api/users"));
+        assertFalse(matchesAsRequest(filter,"/elsewhere"));
+    }
+
+    @Test
+    void doesNotMatchWhenDispatcherTypesLacksRequest() {
+        var filter = filterFor(Set.of("/*"), EnumSet.of(DispatcherType.ASYNC));
+
+        assertFalse(matchesAsRequest(filter,"/anything"));
+    }
+}


### PR DESCRIPTION
Closes #12.

## Problem

`DefaultNettyServletContext` *recorded* filter registrations but the dispatch path called
`DispatcherServlet.service(...)` directly, skipping the filter chain — so every `@Component Filter`
/ `FilterRegistrationBean` bean silently never ran (breaking Spring Security, CORS, request
logging, metrics — #6 depends on this).

Two root-cause gaps were at *registration*, not just dispatch: `addFilter(name, Filter)` discarded
the live instance (kept only the class name), and `addMappingForUrlPatterns(...)` was an empty stub.

## What changed

- **Capture at registration:** `DefaultNettyServletContext` retains the live `Filter` instance plus
  URL patterns + dispatcher types, and exposes them via a memoized `getRegisteredFilters()` snapshot.
- **Real chain:** new `RegisteredFilter` (record + servlet-spec `matches(path, dispatchType)`) and
  `NettyFilterChain` (recursive, terminates in the `DispatcherServlet` as its terminal node).
  Wrapped request/response objects propagate downstream; a filter that doesn't call `chain.doFilter`
  short-circuits the controller.
- **Lifecycle:** `NettyWebServerFactory.initializeFilters()` calls `Filter#init` exactly once at
  startup (fail-fast on `ServletException`); `getDispatcherType()` now returns `REQUEST`.
- **Ordering:** relies on Spring Boot's pre-sorted `ServletContextInitializerBeans` (insertion order
  = `@Order` order); validated by an out-of-declaration-order `@Order(10/20/30)` test.

## Tests

- Unit: `RegisteredFilterTest` (exact/extension/`/*`/`/api/*` boundary/multi-pattern/dispatcher
  gating), `NettyFilterChainTest` (order, short-circuit, terminal-once, wrapper propagation,
  exception propagation), `NettyHttpServletResponseTest`, plus new `DefaultNettyServletContextTest`
  cases.
- Integration (`@SpringBootTest` RANDOM_PORT, isolated fixture app): header set, 403 short-circuit
  (controller not invoked), end-to-end pattern skip, `@Order` ordering, init-once, mid-chain
  exception caught upstream.

Full Spring Security end-to-end test deferred to the v0.5 Security epic (covered here by a generic
403/short-circuit test). `./gradlew build` is green.

## Known limitations (deferred, documented)

`Filter#destroy` not called on shutdown (symmetric with `DispatcherServlet`); `getServletContext()`
returns null on the request; matching uses the percent-decoded path; servlet-name filter mappings
not executed (warns); duplicate filter names overwrite.