### PR TITLE
NL-40: complete NettyHttpServletRequest metadata (network + servletContext/locale/encoding)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,14 @@ Tests use JUnit 6 (`org.junit.gen6`) on JUnit Platform. All test tasks are confi
 
 GitHub Actions (`.github/workflows/build.yml`): builds on push to main and PRs, uses Temurin JDK 25.
 
+## Code Review
+
+The bug-focused review (`/code-review`) is tuned for correctness recall — it requires a concrete failure scenario per finding and ranks correctness above cleanup. That framing structurally under-weights *maintainability and consistency* issues, which have no crash and no quotable rule. After a bug-recall review, run a separate **maintainability/consistency pass** with an explicit lens for the following (read whole files and across the module, not hunk-by-hunk):
+
+- **Naming consistency (convention-by-example).** New types should match the emergent naming of their siblings even when no written rule exists. Example: everything in `core.handler` is `Http`-prefixed (`HttpRequestHandler`, `HttpRequestDispatcher`, `HttpExceptionHandler`, `HttpConnectionMetadata`) — a new class there should carry the prefix.
+- **Magic constants.** Flag bare literals that encode a named concept; prefer a named constant or an existing enum/util. Example: HTTP scheme names and their default ports come from `io.netty.handler.codec.http.HttpScheme` (`HttpScheme.HTTPS.toString()` → `"https"`, `HttpScheme.HTTPS.port()` → `443`) rather than hardcoded `"http"/"https"` or `80/443`. Sentinel values (e.g. `""`/`0` for an unknown address) should be named constants documenting their contract.
+- **Cross-file duplication of the same fact.** Watch for one concept expressed twice in different places — the coupling a per-hunk scan misses. Example: a scheme→port default living as strings in one class and as `80/443` in another is the *same* fact; centralize it in one owner and have the other delegate.
+
 ## Guidelines
 
 Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpConnectionMetadata.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpConnectionMetadata.java
@@ -1,0 +1,51 @@
+package io.github.azholdaspaev.nettyloomspring.core.handler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.ssl.SslHandler;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+public record HttpConnectionMetadata(
+        String remoteAddr, int remotePort,
+        String localAddr, int localPort,
+        boolean secure) {
+
+    /** Servlet contract for an unknown remote/local address (getRemoteAddr/getLocalAddr). */
+    private static final String UNKNOWN_HOST = "";
+    /** Servlet contract for an unknown remote/local port (getRemotePort/getLocalPort). */
+    private static final int UNKNOWN_PORT = 0;
+
+    public static HttpConnectionMetadata from(ChannelHandlerContext ctx) {
+        InetSocketAddress remote = asInet(ctx.channel().remoteAddress());
+        InetSocketAddress local = asInet(ctx.channel().localAddress());
+        boolean secure = ctx.pipeline().get(SslHandler.class) != null;
+        return new HttpConnectionMetadata(host(remote), port(remote), host(local), port(local), secure);
+    }
+
+    public String scheme() {
+        return httpScheme().toString();
+    }
+
+    /** Default port for this connection's scheme (80 for http, 443 for https). */
+    public int defaultPort() {
+        return httpScheme().port();
+    }
+
+    private HttpScheme httpScheme() {
+        return secure ? HttpScheme.HTTPS : HttpScheme.HTTP;
+    }
+
+    private static InetSocketAddress asInet(SocketAddress address) {
+        return address instanceof InetSocketAddress inet ? inet : null;
+    }
+
+    private static String host(InetSocketAddress address) {
+        return address == null ? UNKNOWN_HOST : address.getHostString();
+    }
+
+    private static int port(InetSocketAddress address) {
+        return address == null ? UNKNOWN_PORT : address.getPort();
+    }
+}

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpRequestDispatcher.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpRequestDispatcher.java
@@ -5,5 +5,5 @@ import io.netty.handler.codec.http.FullHttpResponse;
 
 public interface HttpRequestDispatcher {
 
-    FullHttpResponse handle(FullHttpRequest request) throws Exception;
+    FullHttpResponse handle(FullHttpRequest request, HttpConnectionMetadata connection) throws Exception;
 }

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpRequestHandler.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpRequestHandler.java
@@ -19,14 +19,15 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
         request.retain();
-        dispatch(ctx, request);
+        HttpConnectionMetadata connection = HttpConnectionMetadata.from(ctx);
+        dispatch(ctx, request, connection);
     }
 
-    private void dispatch(ChannelHandlerContext ctx, FullHttpRequest request) {
+    private void dispatch(ChannelHandlerContext ctx, FullHttpRequest request, HttpConnectionMetadata connection) {
         try {
             dispatchExecutor.execute(() -> {
                 try {
-                    ctx.writeAndFlush(requestDispatcher.handle(request));
+                    ctx.writeAndFlush(requestDispatcher.handle(request, connection));
                 } catch (Throwable cause) {
                     ctx.fireExceptionCaught(cause);
                 } finally {

--- a/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpConnectionMetadataTest.java
+++ b/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpConnectionMetadataTest.java
@@ -1,0 +1,41 @@
+package io.github.azholdaspaev.nettyloomspring.core.handler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpConnectionMetadataTest {
+
+    @Test
+    void mapsFieldsAndDerivesScheme() {
+        HttpConnectionMetadata insecure = new HttpConnectionMetadata("[::1]", 54321, "10.0.0.1", 8080, false);
+
+        assertEquals("[::1]", insecure.remoteAddr());
+        assertEquals(54321, insecure.remotePort());
+        assertEquals("10.0.0.1", insecure.localAddr());
+        assertEquals(8080, insecure.localPort());
+        assertEquals(false, insecure.secure());
+        assertEquals("http", insecure.scheme());
+
+        HttpConnectionMetadata secure = new HttpConnectionMetadata("10.0.0.2", 443, "10.0.0.1", 8443, true);
+        assertEquals(true, secure.secure());
+        assertEquals("https", secure.scheme());
+    }
+
+    @Test
+    void defaultPortMatchesScheme() {
+        assertEquals(80, new HttpConnectionMetadata("", 0, "", 0, false).defaultPort());
+        assertEquals(443, new HttpConnectionMetadata("", 0, "", 0, true).defaultPort());
+    }
+
+    @Test
+    void fromEmbeddedChannelYieldsDefaults() {
+        ChannelHandlerContext ctx =
+            new EmbeddedChannel(new ChannelInboundHandlerAdapter() {}).pipeline().firstContext();
+
+        assertEquals(new HttpConnectionMetadata("", 0, "", 0, false), HttpConnectionMetadata.from(ctx));
+    }
+}

--- a/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpRequestHandlerTest.java
+++ b/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/handler/HttpRequestHandlerTest.java
@@ -38,7 +38,7 @@ class HttpRequestHandlerTest {
             HttpResponseStatus.OK,
             Unpooled.EMPTY_BUFFER);
         EmbeddedChannel channel = new EmbeddedChannel(
-            new HttpRequestHandler(_ -> canned, DIRECT));
+            new HttpRequestHandler((_, _) -> canned, DIRECT));
 
         channel.writeInbound(new DefaultFullHttpRequest(
             HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
@@ -62,6 +62,23 @@ class HttpRequestHandlerTest {
 
         assertSame(request, dispatcher.lastRequest,
             "handler must hand the inbound request to the dispatcher without wrapping");
+
+        FullHttpResponse out = channel.readOutbound();
+        out.release();
+        channel.finish();
+    }
+
+    @Test
+    void passesHttpConnectionMetadataToDispatcher() {
+        CapturingDispatcher dispatcher = new CapturingDispatcher();
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestHandler(dispatcher, DIRECT));
+
+        channel.writeInbound(new DefaultFullHttpRequest(
+            HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
+        channel.runPendingTasks();
+
+        assertEquals(new HttpConnectionMetadata("", 0, "", 0, false), dispatcher.lastConnection,
+            "handler must snapshot the connection metadata and pass it to the dispatcher");
 
         FullHttpResponse out = channel.readOutbound();
         out.release();
@@ -96,7 +113,7 @@ class HttpRequestHandlerTest {
         RuntimeException boom = new RuntimeException("boom");
         ExceptionCapturingHandler capture = new ExceptionCapturingHandler();
         EmbeddedChannel channel = new EmbeddedChannel(
-            new HttpRequestHandler(_ -> { throw boom; }, DIRECT),
+            new HttpRequestHandler((_, _) -> { throw boom; }, DIRECT),
             capture);
 
         channel.writeInbound(new DefaultFullHttpRequest(
@@ -135,7 +152,7 @@ class HttpRequestHandlerTest {
         Executor rejecting = _ -> { throw rejection; };
         ExceptionCapturingHandler capture = new ExceptionCapturingHandler();
         EmbeddedChannel channel = new EmbeddedChannel(
-            new HttpRequestHandler(_ -> { throw new AssertionError("dispatcher must not run"); }, rejecting),
+            new HttpRequestHandler((_, _) -> { throw new AssertionError("dispatcher must not run"); }, rejecting),
             capture);
         FullHttpRequest request = new DefaultFullHttpRequest(
             HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
@@ -153,11 +170,13 @@ class HttpRequestHandlerTest {
     private static final class CapturingDispatcher implements HttpRequestDispatcher {
 
         FullHttpRequest lastRequest;
+        HttpConnectionMetadata lastConnection;
         int callCount;
 
         @Override
-        public FullHttpResponse handle(FullHttpRequest request) {
+        public FullHttpResponse handle(FullHttpRequest request, HttpConnectionMetadata connection) {
             this.lastRequest = request;
+            this.lastConnection = connection;
             this.callCount++;
             return new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/handler/SpringHttpRequestDispatcher.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/handler/SpringHttpRequestDispatcher.java
@@ -1,5 +1,6 @@
 package io.github.azholdaspaev.nettyloomspring.mvc.handler;
 
+import io.github.azholdaspaev.nettyloomspring.core.handler.HttpConnectionMetadata;
 import io.github.azholdaspaev.nettyloomspring.core.handler.HttpRequestDispatcher;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyFilterChain;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyHttpServletRequest;
@@ -26,8 +27,8 @@ public class SpringHttpRequestDispatcher implements HttpRequestDispatcher {
     }
 
     @Override
-    public FullHttpResponse handle(FullHttpRequest request) throws Exception {
-        NettyHttpServletRequest servletRequest = new NettyHttpServletRequest(request);
+    public FullHttpResponse handle(FullHttpRequest request, HttpConnectionMetadata connection) throws Exception {
+        NettyHttpServletRequest servletRequest = new NettyHttpServletRequest(request, connection, servletContext);
         NettyHttpServletResponse servletResponse = new NettyHttpServletResponse();
 
         String requestPath = servletRequest.getRequestURI();

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
@@ -1,5 +1,6 @@
 package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
 
+import io.github.azholdaspaev.nettyloomspring.core.handler.HttpConnectionMetadata;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.handler.codec.DateFormatter;
@@ -30,8 +31,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,39 +48,73 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.springframework.http.HttpHeaders;
+
 public class NettyHttpServletRequest implements HttpServletRequest {
 
     private final FullHttpRequest nettyRequest;
+    private final HttpConnectionMetadata connection;
+    private final NettyServletContext servletContext;
 
     private final Map<String, Object> attributes = new HashMap<>();
     private final String requestURI;
     private final String queryString;
-    private final Map<String, String[]> parameterMap;
-    private final Charset characterEncoding;
+    private final QueryStringDecoder queryDecoder;
+    private boolean hostResolved;
+    private String serverName;
+    private int serverPort;
+    private Map<String, String[]> parameterMap;
+    private List<Locale> locales;
+    private Charset characterEncoding;
     private ServletInputStream inputStream;
     private BufferedReader reader;
 
-    public NettyHttpServletRequest(FullHttpRequest nettyRequest) {
+    public NettyHttpServletRequest(FullHttpRequest nettyRequest,
+                                   HttpConnectionMetadata connection,
+                                   NettyServletContext servletContext) {
         this.nettyRequest = nettyRequest;
+        this.connection = connection;
+        this.servletContext = servletContext;
 
-        QueryStringDecoder decoder = new QueryStringDecoder(nettyRequest.uri());
-        this.requestURI = decoder.path();
-        String rawQuery = decoder.rawQuery();
+        this.queryDecoder = new QueryStringDecoder(nettyRequest.uri());
+        this.requestURI = queryDecoder.path();
+        String rawQuery = queryDecoder.rawQuery();
         this.queryString = rawQuery.isEmpty() ? null : rawQuery;
         this.characterEncoding = HttpUtil.getCharset(nettyRequest, null);
+    }
 
-        Map<String, List<String>> merged = new LinkedHashMap<>(decoder.parameters());
-        mergeFormBodyParameters(merged);
+    private void ensureHostResolved() {
+        if (hostResolved) {
+            return;
+        }
+        InetSocketAddress host = parseHostHeader(nettyRequest.headers().get(HttpHeaderNames.HOST));
+        if (host != null) {
+            this.serverName = host.getHostString();
+            this.serverPort = resolvePort(host.getPort());
+        } else {
+            this.serverName = bracketIfIpv6(connection.localAddr());
+            this.serverPort = resolvePort(connection.localPort());
+        }
+        this.hostResolved = true;
+    }
+
+    private void ensureParametersParsed() {
+        if (parameterMap != null) {
+            return;
+        }
+        Charset bodyCharset = characterEncoding != null ? characterEncoding : StandardCharsets.UTF_8;
+        // queryDecoder defaults to UTF-8, keeping query decoding independent of the body charset.
+        Map<String, List<String>> merged = new LinkedHashMap<>(queryDecoder.parameters());
+        mergeFormBodyParameters(merged, bodyCharset);
         this.parameterMap = toParameterMap(merged);
     }
 
-    private void mergeFormBodyParameters(Map<String, List<String>> target) {
+    private void mergeFormBodyParameters(Map<String, List<String>> target, Charset charset) {
         CharSequence mimeType = HttpUtil.getMimeType(nettyRequest);
         if (mimeType == null
             || !AsciiString.contentEqualsIgnoreCase(mimeType, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED)) {
             return;
         }
-        Charset charset = characterEncoding != null ? characterEncoding : StandardCharsets.UTF_8;
         String body = nettyRequest.content().toString(charset);
         if (body.isEmpty()) {
             return;
@@ -85,6 +123,34 @@ public class NettyHttpServletRequest implements HttpServletRequest {
             new QueryStringDecoder(body, charset, false).parameters();
         formParams.forEach((name, values) ->
             target.computeIfAbsent(name, k -> new ArrayList<>()).addAll(values));
+    }
+
+    private int defaultPort() {
+        return connection.defaultPort();
+    }
+
+    private int resolvePort(int candidatePort) {
+        return candidatePort > 0 ? candidatePort : defaultPort();
+    }
+
+    private static String bracketIfIpv6(String host) {
+        if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
+            return "[" + host + "]";
+        }
+        return host;
+    }
+
+    private static InetSocketAddress parseHostHeader(String host) {
+        if (host == null || host.isBlank()) {
+            return null;
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.HOST, host.trim());
+        InetSocketAddress address = headers.getHost();
+        if (address == null || address.getHostString().isBlank()) {
+            return null;
+        }
+        return address;
     }
 
     private static Map<String, String[]> toParameterMap(Map<String, List<String>> parameters) {
@@ -192,7 +258,19 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public StringBuffer getRequestURL() {
-        return null;
+        ensureHostResolved();
+        String authority = serverName;
+        if (authority == null || authority.isBlank()) {
+            authority = connection.localAddr();
+        }
+        StringBuffer url = new StringBuffer(connection.scheme()).append(':');
+        if (authority != null && !authority.isBlank()) {
+            url.append("//").append(authority);
+            if (serverPort != defaultPort()) {
+                url.append(':').append(serverPort);
+            }
+        }
+        return url.append(requestURI);
     }
 
     @Override
@@ -277,7 +355,18 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public void setCharacterEncoding(String encoding) throws UnsupportedEncodingException {
-
+        if (parameterMap != null || reader != null) {
+            return;
+        }
+        if (encoding == null) {
+            characterEncoding = null;
+            return;
+        }
+        try {
+            characterEncoding = Charset.forName(encoding);
+        } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+            throw new UnsupportedEncodingException(encoding);
+        }
     }
 
     @Override
@@ -336,44 +425,50 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getParameter(String name) {
+        ensureParametersParsed();
         String[] values = parameterMap.get(name);
         return values == null ? null : values[0];
     }
 
     @Override
     public Enumeration<String> getParameterNames() {
+        ensureParametersParsed();
         return Collections.enumeration(parameterMap.keySet());
     }
 
     @Override
     public String[] getParameterValues(String name) {
+        ensureParametersParsed();
         String[] values = parameterMap.get(name);
         return values == null ? null : values.clone();
     }
 
     @Override
     public Map<String, String[]> getParameterMap() {
+        ensureParametersParsed();
         return parameterMap;
     }
 
     @Override
     public String getProtocol() {
-        return "";
+        return nettyRequest.protocolVersion().text();
     }
 
     @Override
     public String getScheme() {
-        return "";
+        return connection.scheme();
     }
 
     @Override
     public String getServerName() {
-        return "";
+        ensureHostResolved();
+        return serverName;
     }
 
     @Override
     public int getServerPort() {
-        return 0;
+        ensureHostResolved();
+        return serverPort;
     }
 
     @Override
@@ -382,7 +477,7 @@ public class NettyHttpServletRequest implements HttpServletRequest {
             throw new IllegalStateException("getInputStream() has already been called on this request");
         }
         if (reader == null) {
-            Charset charset = characterEncoding != null ? characterEncoding : StandardCharsets.ISO_8859_1;
+            Charset charset = characterEncoding != null ? characterEncoding : StandardCharsets.UTF_8;
             ByteBufInputStream stream = new ByteBufInputStream(nettyRequest.content().duplicate());
             reader = new BufferedReader(new InputStreamReader(stream, charset));
         }
@@ -391,12 +486,12 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getRemoteAddr() {
-        return "";
+        return connection.remoteAddr();
     }
 
     @Override
     public String getRemoteHost() {
-        return "";
+        return connection.remoteAddr();
     }
 
     @Override
@@ -415,17 +510,45 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public Locale getLocale() {
-        return null;
+        return resolveLocales().get(0);
     }
 
     @Override
     public Enumeration<Locale> getLocales() {
-        return null;
+        return Collections.enumeration(resolveLocales());
+    }
+
+    private List<Locale> resolveLocales() {
+        if (locales != null) {
+            return locales;
+        }
+        locales = parseLocales();
+        return locales;
+    }
+
+    private List<Locale> parseLocales() {
+        String header = nettyRequest.headers().get(HttpHeaderNames.ACCEPT_LANGUAGE);
+        if (header == null || header.isBlank()) {
+            return List.of(Locale.getDefault());
+        }
+        List<Locale> locales;
+        try {
+            locales = Locale.LanguageRange.parse(header).stream()
+                .filter(range -> range.getWeight() > 0)
+                .map(Locale.LanguageRange::getRange)
+                .filter(range -> !range.equals("*"))
+                .map(Locale::forLanguageTag)
+                .filter(locale -> !locale.toLanguageTag().equals("und"))
+                .toList();
+        } catch (IllegalArgumentException e) {
+            return List.of(Locale.getDefault());
+        }
+        return locales.isEmpty() ? List.of(Locale.getDefault()) : locales;
     }
 
     @Override
     public boolean isSecure() {
-        return false;
+        return connection.secure();
     }
 
     @Override
@@ -435,27 +558,27 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public int getRemotePort() {
-        return 0;
+        return connection.remotePort();
     }
 
     @Override
     public String getLocalName() {
-        return "";
+        return connection.localAddr();
     }
 
     @Override
     public String getLocalAddr() {
-        return "";
+        return connection.localAddr();
     }
 
     @Override
     public int getLocalPort() {
-        return 0;
+        return connection.localPort();
     }
 
     @Override
     public ServletContext getServletContext() {
-        return null;
+        return servletContext;
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterChainTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyFilterChainTest.java
@@ -1,5 +1,6 @@
 package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
 
+import io.github.azholdaspaev.nettyloomspring.core.handler.HttpConnectionMetadata;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
@@ -91,7 +92,9 @@ class NettyFilterChainTest {
     @Test
     void propagatesRequestAndResponseWrappersToDownstreamFilterAndTerminal() throws Exception {
         var original = new NettyHttpServletRequest(
-            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/x"));
+            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/x"),
+            new HttpConnectionMetadata("", 0, "", 0, false),
+            new DefaultNettyServletContext());
         var wrappedRequest = new HttpServletRequestWrapper(original);
         var wrappedResponse = new HttpServletResponseWrapper(new NettyHttpServletResponse());
 

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
@@ -1,0 +1,285 @@
+package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
+
+import io.github.azholdaspaev.nettyloomspring.core.handler.HttpConnectionMetadata;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NettyHttpServletRequestTest {
+
+    private static NettyHttpServletRequest request(HttpConnectionMetadata connection, NettyServletContext context) {
+        return new NettyHttpServletRequest(
+            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/x"),
+            connection,
+            context);
+    }
+
+    private static NettyHttpServletRequest request(String uri, String host, HttpConnectionMetadata connection) {
+        var nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+        if (host != null) {
+            nettyRequest.headers().set(HttpHeaderNames.HOST, host);
+        }
+        return new NettyHttpServletRequest(nettyRequest, connection, new DefaultNettyServletContext());
+    }
+
+    private static NettyHttpServletRequest formRequest(String uri, byte[] body, HttpConnectionMetadata connection) {
+        var nettyRequest = new DefaultFullHttpRequest(
+            HttpVersion.HTTP_1_1, HttpMethod.POST, uri, Unpooled.wrappedBuffer(body));
+        nettyRequest.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED);
+        return new NettyHttpServletRequest(nettyRequest, connection, new DefaultNettyServletContext());
+    }
+
+    private static NettyHttpServletRequest requestWithAcceptLanguage(String acceptLanguage, HttpConnectionMetadata connection) {
+        var nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/x");
+        nettyRequest.headers().set(HttpHeaderNames.ACCEPT_LANGUAGE, acceptLanguage);
+        return new NettyHttpServletRequest(nettyRequest, connection, new DefaultNettyServletContext());
+    }
+
+    @Test
+    void networkGettersFromConnection() {
+        var context = new DefaultNettyServletContext();
+        var request = request(new HttpConnectionMetadata("203.0.113.7", 54321, "198.51.100.2", 8080, false), context);
+
+        assertEquals("203.0.113.7", request.getRemoteAddr());
+        assertEquals("203.0.113.7", request.getRemoteHost());
+        assertEquals(54321, request.getRemotePort());
+        assertEquals("198.51.100.2", request.getLocalAddr());
+        assertEquals("198.51.100.2", request.getLocalName());
+        assertEquals(8080, request.getLocalPort());
+        assertEquals("http", request.getScheme());
+        assertFalse(request.isSecure());
+        assertSame(context, request.getServletContext());
+    }
+
+    @Test
+    void remoteAndLocalHostsAreNotReverseDnsResolvedForIpv6() {
+        var request = request(
+            new HttpConnectionMetadata("::1", 9999, "::1", 8080, false),
+            new DefaultNettyServletContext());
+
+        assertEquals("::1", request.getRemoteAddr());
+        assertEquals("::1", request.getRemoteHost());
+        assertEquals("::1", request.getLocalAddr());
+        assertEquals("::1", request.getLocalName());
+    }
+
+    @Test
+    void protocolReflectsHttpVersion() {
+        var request = request(new HttpConnectionMetadata("", 0, "", 0, false), new DefaultNettyServletContext());
+
+        assertEquals("HTTP/1.1", request.getProtocol());
+    }
+
+    @Test
+    void serverNamePortFromHostHeader() {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+
+        var hostOnly = request("/x", "example.com", insecure);
+        assertEquals("example.com", hostOnly.getServerName());
+        assertEquals(80, hostOnly.getServerPort());
+
+        var hostPort = request("/x", "example.com:8443", insecure);
+        assertEquals("example.com", hostPort.getServerName());
+        assertEquals(8443, hostPort.getServerPort());
+
+        var ipv6Port = request("/x", "[::1]:8080", insecure);
+        assertEquals("[::1]", ipv6Port.getServerName());
+        assertEquals(8080, ipv6Port.getServerPort());
+
+        var ipv6NoPort = request("/x", "[::1]", insecure);
+        assertEquals("[::1]", ipv6NoPort.getServerName());
+        assertEquals(80, ipv6NoPort.getServerPort());
+
+        var noHost = request("/x", null, insecure);
+        assertEquals("198.51.100.9", noHost.getServerName());
+        assertEquals(7070, noHost.getServerPort());
+
+        var underscored = request("/x", "redis_master:6379", insecure);
+        assertEquals("redis_master", underscored.getServerName());
+        assertEquals(6379, underscored.getServerPort());
+
+        var blank = request("/x", "", insecure);
+        assertEquals("198.51.100.9", blank.getServerName());
+        assertEquals(7070, blank.getServerPort());
+    }
+
+    @Test
+    void ipv6ServerNameIsBracketedWhileLocalAddrStaysRaw() {
+        // No Host header: serverName falls back to the local socket. For URL/authority use the IPv6
+        // address must be bracketed, but the Servlet-spec numeric getLocalAddr()/getLocalName() must
+        // remain the raw, unbracketed IP.
+        var request = request("/x", null, new HttpConnectionMetadata("::1", 9999, "::1", 8080, false));
+
+        assertEquals("[::1]", request.getServerName());
+        assertEquals("http://[::1]:8080/x", request.getRequestURL().toString());
+        assertEquals("::1", request.getLocalAddr());
+        assertEquals("::1", request.getLocalName());
+    }
+
+    @Test
+    void requestUrlWithoutHostAndEmptyLocalAddrOmitsAuthority() {
+        // No Host header and a non-Inet local address (empty localAddr): the URL must not become the
+        // malformed "http:///x" with an empty authority.
+        var request = request("/x", null, new HttpConnectionMetadata("", 0, "", 0, false));
+
+        assertEquals("http:/x", request.getRequestURL().toString());
+    }
+
+    @Test
+    void localesParseQOrderAndDefault() {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+
+        var ordered = requestWithAcceptLanguage("da, en-gb;q=0.8, en;q=0.7", insecure);
+        assertEquals(Locale.forLanguageTag("da"), ordered.getLocale());
+        assertEquals(
+            List.of(Locale.forLanguageTag("da"), Locale.forLanguageTag("en-gb"), Locale.forLanguageTag("en")),
+            Collections.list(ordered.getLocales()));
+
+        var equalWeight = requestWithAcceptLanguage("en, fr", insecure);
+        assertEquals(
+            List.of(Locale.forLanguageTag("en"), Locale.forLanguageTag("fr")),
+            Collections.list(equalWeight.getLocales()));
+
+        var rejected = requestWithAcceptLanguage("en;q=0", insecure);
+        assertEquals(Locale.getDefault(), rejected.getLocale());
+        assertEquals(List.of(Locale.getDefault()), Collections.list(rejected.getLocales()));
+
+        var absent = request("/x", null, insecure);
+        assertEquals(Locale.getDefault(), absent.getLocale());
+        assertEquals(List.of(Locale.getDefault()), Collections.list(absent.getLocales()));
+
+        var wildcardOnly = requestWithAcceptLanguage("*", insecure);
+        assertEquals(Locale.getDefault(), wildcardOnly.getLocale());
+
+        var malformed = requestWithAcceptLanguage("not a valid range!!!", insecure);
+        assertEquals(Locale.getDefault(), malformed.getLocale());
+
+        assertNotNull(ordered.getLocale());
+        assertTrue(Collections.list(ordered.getLocales()).size() >= 1);
+    }
+
+    @Test
+    void localesAreCachedOnFirstAccessAndReused() {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+        var nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/x");
+        nettyRequest.headers().set(HttpHeaderNames.ACCEPT_LANGUAGE, "da, en-gb;q=0.8, en;q=0.7");
+        var request = new NettyHttpServletRequest(nettyRequest, insecure, new DefaultNettyServletContext());
+
+        assertEquals(Locale.forLanguageTag("da"), request.getLocale());
+        List<Locale> first = Collections.list(request.getLocales());
+
+        // Mutating the header after the first resolution must not change the result: parsing happens once.
+        nettyRequest.headers().set(HttpHeaderNames.ACCEPT_LANGUAGE, "fr");
+        assertEquals(Locale.forLanguageTag("da"), request.getLocale());
+        assertEquals(first, Collections.list(request.getLocales()));
+        assertEquals(
+            List.of(Locale.forLanguageTag("da"), Locale.forLanguageTag("en-gb"), Locale.forLanguageTag("en")),
+            first);
+    }
+
+    @Test
+    void requestUrlOmitsDefaultPortAndQuery() {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+        var secure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, true);
+
+        var defaultHttp = request("/foo", "example.com", insecure);
+        assertEquals("http://example.com/foo", defaultHttp.getRequestURL().toString());
+
+        var defaultHttps = request("/foo", "example.com", secure);
+        assertEquals("https://example.com/foo", defaultHttps.getRequestURL().toString());
+
+        var combined = request("/app/x?q=1", "example.com:8443", secure);
+        assertEquals("https://example.com:8443/app/x", combined.getRequestURL().toString());
+        assertInstanceOf(StringBuffer.class, combined.getRequestURL());
+    }
+
+    @Test
+    void paramsParseLazilyOnFirstAccess() {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+        var request = formRequest("/x?a=1", "b=2".getBytes(StandardCharsets.UTF_8), insecure);
+
+        assertEquals("1", request.getParameter("a"));
+        assertEquals("2", request.getParameter("b"));
+        assertEquals(2, request.getParameterMap().size());
+        assertSame(request.getParameterMap(), request.getParameterMap());
+    }
+
+    @Test
+    void queryStringDecodedAsUtf8IndependentOfBodyEncoding() throws Exception {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+        // %C3%A9 is the UTF-8 encoding of "é". The query must always decode as UTF-8, while the
+        // form body must honor the body charset set via setCharacterEncoding.
+        var request = formRequest("/x?q=%C3%A9", "name=%C3%A9".getBytes(StandardCharsets.US_ASCII), insecure);
+        request.setCharacterEncoding("ISO-8859-1");
+
+        assertEquals("é", request.getParameter("q"));
+        // Bytes 0xC3 0xA9 decoded as ISO-8859-1 -> "Ã©", proving the body charset applies to the body only.
+        assertEquals("Ã©", request.getParameter("name"));
+    }
+
+    @Test
+    void readerDefaultCharsetMatchesParameterParsing() throws Exception {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+        // No charset set anywhere: getReader() and parameter parsing must agree on the default.
+        byte[] body = new byte[] {'v', '=', (byte) 0xE9};
+
+        var viaReader = formRequest("/x", body, insecure);
+        var viaParam = formRequest("/x", body, insecure);
+
+        String paramValue = viaParam.getParameter("v");
+        assertEquals("�", paramValue);
+        assertEquals("v=" + paramValue, viaReader.getReader().readLine());
+    }
+
+    @Test
+    void setEncodingBeforeReadAffectsParamsThenLocks() throws Exception {
+        var insecure = new HttpConnectionMetadata("198.51.100.2", 1, "198.51.100.9", 7070, false);
+        // 0xE9 decodes to "é" in ISO-8859-1, and to the replacement char in UTF-8.
+        byte[] body = new byte[] {'n', 'a', 'm', 'e', '=', (byte) 0xE9};
+
+        var beforeRead = formRequest("/x", body, insecure);
+        assertNull(beforeRead.getCharacterEncoding());
+        beforeRead.setCharacterEncoding("ISO-8859-1");
+        assertEquals("ISO-8859-1", beforeRead.getCharacterEncoding());
+        assertEquals("é", beforeRead.getParameter("name"));
+        // First getParameter locked the encoding -> later setCharacterEncoding is a no-op.
+        beforeRead.setCharacterEncoding("UTF-8");
+        assertEquals("ISO-8859-1", beforeRead.getCharacterEncoding());
+
+        var viaReader = formRequest("/x", body, insecure);
+        viaReader.setCharacterEncoding("UTF-8");
+        assertEquals("name=�", viaReader.getReader().readLine());
+        // getReader locked the encoding too.
+        viaReader.setCharacterEncoding("ISO-8859-1");
+        assertEquals("UTF-8", viaReader.getCharacterEncoding());
+
+        var badCharset = formRequest("/x", body, insecure);
+        assertThrows(UnsupportedEncodingException.class, () -> badCharset.setCharacterEncoding("no-such-charset!!"));
+
+        // getInputStream consumes bytes, not the charset, so it must NOT lock the encoding.
+        var viaStream = formRequest("/x", body, insecure);
+        viaStream.getInputStream();
+        viaStream.setCharacterEncoding("ISO-8859-1");
+        assertEquals("ISO-8859-1", viaStream.getCharacterEncoding());
+        assertEquals("é", viaStream.getParameter("name"));
+    }
+}


### PR DESCRIPTION
Closes #40.

Completes the missing `NettyHttpServletRequest` metadata getters needed by Spring Security and Actuator (absolute URLs, redirects, locale, request-scoped context).

## Design

The dispatcher SPI was connection-blind (`handle(FullHttpRequest)`). Introduced a small immutable **`HttpConnectionMetadata`** record (`core.handler`), snapshotted on the Netty event loop in `HttpRequestHandler` and threaded through the SPI into `NettyHttpServletRequest`. Keeps the Spring layer free of raw Netty `Channel`/`java.net` types and is trivially constructible in tests (no Mockito).

## What's implemented

- **Network:** `getScheme`/`isSecure` (derived from `SslHandler` presence), `getRemoteAddr`/`Host`/`Port`, `getLocalAddr`/`Name`/`Port`, `getProtocol`, `getServerName`/`getServerPort` (Host-header precedence via Spring `HttpHeaders.getHost()`, local-socket fallback), `getRequestURL` (default-port omission, IPv6 bracketing).
- **Servlet infra:** `getServletContext()` returns the real context (unblocks `RequestContextHolder`/`WebAsyncManager`). `getRequestDispatcher()` returns `null` — forward/include deferred (see Scope).
- **i18n/encoding:** `getLocale`/`getLocales` parse `Accept-Language` (q-weight order, drops `q=0`/`*`/`und`, default fallback, cached). Lazy, spec-faithful `setCharacterEncoding` (query pinned to UTF-8; body uses the request charset).

## Scope boundaries (deliberate)

- `getRequestDispatcher()` returns `null` — real forward/include (re-entrant `DispatcherServlet`) is a separate feature. **The #40 acceptance text mentions a "working dispatcher"; that item is deferred and should be tracked as a follow-up or the checkbox amended.**
- `getSession()` stays `null` (session-backed Security/Actuator out of scope).
- `getReader()` no-charset default aligned to UTF-8 (matches param parsing; diverges from strict-spec ISO-8859-1 by choice).

## Quality

Built via TDD; ran a high-effort correctness review (10 findings, all fixed), a `/simplify` cleanup pass, a magic-constant refactor (reuse Netty `HttpScheme`), and renamed `ConnectionMetadata` → `HttpConnectionMetadata` to match the `Http`-prefixed siblings in `core.handler`. Added a Code Review section to `CLAUDE.md` documenting a maintainability/consistency pass.

## Verification

`./gradlew build` — BUILD SUCCESSFUL across all modules incl. the starter's end-to-end `SmokeControllerTest`. ~10 new unit tests in `HttpConnectionMetadataTest` + `NettyHttpServletRequestTest`.