### PR TITLE
NL-11 Implement cookie reading and writing

### DIFF
--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/cookie/CookieIntegrationTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/cookie/CookieIntegrationTest.java
@@ -1,0 +1,96 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.cookie;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.cookie.app.CookieTestApplication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@AutoConfigureRestTestClient
+@SpringBootTest(
+    classes = CookieTestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class CookieIntegrationTest {
+
+    @Autowired
+    private RestTestClient restTestClient;
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void cookieValueResolvesSingleCookie() {
+        restTestClient.get().uri("/cookie/read")
+            .header("Cookie", "foo=bar")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("bar");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void getCookiesPreservesOrderAcrossPairs() {
+        restTestClient.get().uri("/cookie/read-all")
+            .header("Cookie", "a=1; b=2; c=3")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("a,b,c");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void missingRequiredCookieYields400() {
+        restTestClient.get().uri("/cookie/read")
+            .exchange()
+            .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void writtenCookieRoundTripsOnSecondRequest() {
+        // RestTestClient does not persist cookies across exchanges; capture and resend manually.
+        restTestClient.get().uri("/cookie/set")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().exists(HttpHeaders.SET_COOKIE);
+
+        restTestClient.get().uri("/cookie/echo")
+            .cookie("sid", "xyz")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("xyz");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void cookieAttributesAreSerialisedFaithfully() {
+        String setCookie = restTestClient.get().uri("/cookie/set-attrs")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).returnResult().getResponseBody();
+
+        assertNotNull(setCookie);
+        assertTrue(setCookie.contains("Path="), setCookie);
+        assertTrue(setCookie.contains("Domain="), setCookie);
+        assertTrue(setCookie.contains("Secure"), setCookie);
+        assertTrue(setCookie.contains("HTTPOnly"), setCookie);
+        assertTrue(setCookie.contains("Max-Age="), setCookie);
+        assertTrue(setCookie.contains("SameSite=Lax"), setCookie);
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void malformedCookieHeaderIsToleratedWithoutError() {
+        restTestClient.get().uri("/cookie/read-all")
+            .header("Cookie", "=;;garbage")
+            .exchange()
+            .expectStatus().isOk();
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/cookie/app/CookieController.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/cookie/app/CookieController.java
@@ -1,0 +1,55 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.cookie.app;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@RestController
+public class CookieController {
+
+    @GetMapping("/cookie/read")
+    public String read(@CookieValue("foo") String foo) {
+        return foo;
+    }
+
+    @GetMapping("/cookie/read-all")
+    public String readAll(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return "";
+        }
+        return Arrays.stream(cookies)
+            .map(Cookie::getName)
+            .collect(Collectors.joining(","));
+    }
+
+    @GetMapping("/cookie/set")
+    public String set(HttpServletResponse response) {
+        response.addCookie(new Cookie("sid", "xyz"));
+        return "set";
+    }
+
+    @GetMapping("/cookie/echo")
+    public String echo(@CookieValue(value = "sid", required = false) String sid) {
+        return sid;
+    }
+
+    @GetMapping("/cookie/set-attrs")
+    public String setAttrs(HttpServletResponse response) {
+        Cookie cookie = new Cookie("sid", "xyz");
+        cookie.setPath("/");
+        cookie.setDomain("example.com");
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(3600);
+        cookie.setAttribute("SameSite", "Lax");
+        response.addCookie(cookie);
+        return String.join(",", response.getHeaders("Set-Cookie"));
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/cookie/app/CookieTestApplication.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/cookie/app/CookieTestApplication.java
@@ -1,0 +1,11 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.cookie.app;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Isolated test application for the cookie integration tests. Kept in its own package so its
+ * fixture controller does not bleed into the {@code smoke.app} component scan (and vice versa).
+ */
+@SpringBootApplication
+public class CookieTestApplication {
+}

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
@@ -188,7 +188,8 @@ public class NettyHttpServletRequest implements HttpServletRequest {
     @Override
     public Cookie[] getCookies() {
         ensureCookiesParsed();
-        return cookies;
+        // Defensive copy (parity with getParameterValues): callers can't corrupt the cached array.
+        return cookies == null ? null : cookies.clone();
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
@@ -9,6 +9,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.util.AsciiString;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
@@ -66,6 +67,8 @@ public class NettyHttpServletRequest implements HttpServletRequest {
     private Map<String, String[]> parameterMap;
     private List<Locale> locales;
     private Charset characterEncoding;
+    private Cookie[] cookies;
+    private boolean cookiesParsed;
     private ServletInputStream inputStream;
     private BufferedReader reader;
 
@@ -107,6 +110,24 @@ public class NettyHttpServletRequest implements HttpServletRequest {
         Map<String, List<String>> merged = new LinkedHashMap<>(queryDecoder.parameters());
         mergeFormBodyParameters(merged, bodyCharset);
         this.parameterMap = toParameterMap(merged);
+    }
+
+    private void ensureCookiesParsed() {
+        if (cookiesParsed) {
+            return;
+        }
+        this.cookies = parseCookies();
+        this.cookiesParsed = true;
+    }
+
+    private Cookie[] parseCookies() {
+        List<Cookie> parsed = new ArrayList<>();
+        for (String header : nettyRequest.headers().getAll(HttpHeaderNames.COOKIE)) {
+            for (io.netty.handler.codec.http.cookie.Cookie cookie : ServerCookieDecoder.STRICT.decodeAll(header)) {
+                parsed.add(new Cookie(cookie.name(), cookie.value()));
+            }
+        }
+        return parsed.isEmpty() ? null : parsed.toArray(new Cookie[0]);
     }
 
     private void mergeFormBodyParameters(Map<String, List<String>> target, Charset charset) {
@@ -166,7 +187,8 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public Cookie[] getCookies() {
-        return new Cookie[0];
+        ensureCookiesParsed();
+        return cookies;
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponse.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponse.java
@@ -7,6 +7,9 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.cookie.CookieHeaderNames;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.Cookie;
@@ -25,6 +28,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 public class NettyHttpServletResponse implements HttpServletResponse {
 
@@ -37,6 +41,40 @@ public class NettyHttpServletResponse implements HttpServletResponse {
 
     @Override
     public void addCookie(Cookie cookie) {
+        DefaultCookie nettyCookie = new DefaultCookie(cookie.getName(), Objects.requireNonNullElse(cookie.getValue(), ""));
+        if (cookie.getPath() != null) {
+            nettyCookie.setPath(cookie.getPath());
+        }
+        if (cookie.getDomain() != null) {
+            nettyCookie.setDomain(cookie.getDomain());
+        }
+        // maxAge -1 marks a session cookie: leave Max-Age unset rather than emitting it.
+        if (cookie.getMaxAge() >= 0) {
+            nettyCookie.setMaxAge(cookie.getMaxAge());
+        }
+        nettyCookie.setSecure(cookie.getSecure());
+        nettyCookie.setHttpOnly(cookie.isHttpOnly());
+        CookieHeaderNames.SameSite sameSite = parseSameSite(cookie.getAttribute("SameSite"));
+        if (sameSite != null) {
+            nettyCookie.setSameSite(sameSite);
+        }
+        // version is intentionally NOT propagated: RFC 6265 / Netty have no Version field.
+        // STRICT validates RFC 6265 name/value octets and throws IllegalArgumentException for invalid
+        // input; we let it propagate (fail-fast, matching Tomcat's Rfc6265CookieProcessor) rather than
+        // silently dropping or mangling the cookie.
+        headers.add(HttpHeaders.SET_COOKIE, ServerCookieEncoder.STRICT.encode(nettyCookie));
+    }
+
+    private static CookieHeaderNames.SameSite parseSameSite(String value) {
+        if (value == null) {
+            return null;
+        }
+        for (CookieHeaderNames.SameSite candidate : CookieHeaderNames.SameSite.values()) {
+            if (candidate.name().equalsIgnoreCase(value)) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponse.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponse.java
@@ -32,6 +32,9 @@ import java.util.Objects;
 
 public class NettyHttpServletResponse implements HttpServletResponse {
 
+    // Hoisted so parseSameSite doesn't clone a fresh enum array on every addCookie (write path).
+    private static final CookieHeaderNames.SameSite[] SAME_SITE_VALUES = CookieHeaderNames.SameSite.values();
+
     private final FastByteArrayOutputStream body = new FastByteArrayOutputStream(256);
     private final HttpHeaders headers = new HttpHeaders();
     private int status = HttpServletResponse.SC_OK;
@@ -54,11 +57,17 @@ public class NettyHttpServletResponse implements HttpServletResponse {
         }
         nettyCookie.setSecure(cookie.getSecure());
         nettyCookie.setHttpOnly(cookie.isHttpOnly());
-        CookieHeaderNames.SameSite sameSite = parseSameSite(cookie.getAttribute("SameSite"));
+        CookieHeaderNames.SameSite sameSite = parseSameSite(cookie.getAttribute(CookieHeaderNames.SAMESITE));
         if (sameSite != null) {
             nettyCookie.setSameSite(sameSite);
         }
-        // version is intentionally NOT propagated: RFC 6265 / Netty have no Version field.
+        // CHIPS: propagate Partitioned when the attribute is present (its value is conventionally empty).
+        if (cookie.getAttribute(CookieHeaderNames.PARTITIONED) != null) {
+            nettyCookie.setPartitioned(true);
+        }
+        // Only the attributes above are mapped; Netty's Cookie has no arbitrary-attribute setter, so any
+        // other Servlet 6.0 attribute (e.g. Expires) is dropped. version is likewise NOT propagated: RFC
+        // 6265 / Netty have no Version field.
         // STRICT validates RFC 6265 name/value octets and throws IllegalArgumentException for invalid
         // input; we let it propagate (fail-fast, matching Tomcat's Rfc6265CookieProcessor) rather than
         // silently dropping or mangling the cookie.
@@ -69,8 +78,10 @@ public class NettyHttpServletResponse implements HttpServletResponse {
         if (value == null) {
             return null;
         }
-        for (CookieHeaderNames.SameSite candidate : CookieHeaderNames.SameSite.values()) {
-            if (candidate.name().equalsIgnoreCase(value)) {
+        // Trim so a padded value (e.g. " Strict ") isn't silently dropped, weakening the policy.
+        String trimmed = value.trim();
+        for (CookieHeaderNames.SameSite candidate : SAME_SITE_VALUES) {
+            if (candidate.name().equalsIgnoreCase(trimmed)) {
                 return candidate;
             }
         }

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
@@ -7,6 +7,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
@@ -15,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -281,5 +283,82 @@ class NettyHttpServletRequestTest {
         viaStream.setCharacterEncoding("ISO-8859-1");
         assertEquals("ISO-8859-1", viaStream.getCharacterEncoding());
         assertEquals("é", viaStream.getParameter("name"));
+    }
+
+    private static NettyHttpServletRequest cookieRequest(String... cookieHeaders) {
+        var nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        for (String header : cookieHeaders) {
+            nettyRequest.headers().add(HttpHeaderNames.COOKIE, header);
+        }
+        return new NettyHttpServletRequest(
+            nettyRequest,
+            new HttpConnectionMetadata("", 0, "", 0, false),
+            new DefaultNettyServletContext());
+    }
+
+    @Test
+    void getCookiesParsesSingleCookie() {
+        Cookie[] cookies = cookieRequest("foo=bar").getCookies();
+
+        assertEquals(1, cookies.length);
+        assertEquals("foo", cookies[0].getName());
+        assertEquals("bar", cookies[0].getValue());
+    }
+
+    @Test
+    void getCookiesPreservesOrderOfMultiplePairs() {
+        Cookie[] cookies = cookieRequest("a=1; b=2; c=3").getCookies();
+
+        assertEquals(3, cookies.length);
+        assertEquals("a", cookies[0].getName());
+        assertEquals("b", cookies[1].getName());
+        assertEquals("c", cookies[2].getName());
+    }
+
+    @Test
+    void getCookiesReadsMultipleCookieHeaders() {
+        Cookie[] cookies = cookieRequest("a=1", "b=2").getCookies();
+
+        assertEquals(2, cookies.length);
+        assertEquals("a", cookies[0].getName());
+        assertEquals("1", cookies[0].getValue());
+        assertEquals("b", cookies[1].getName());
+        assertEquals("2", cookies[1].getValue());
+    }
+
+    @Test
+    void getCookiesKeepsDuplicateNamesInOrder() {
+        Cookie[] cookies = cookieRequest("foo=1; foo=2").getCookies();
+
+        assertEquals(2, cookies.length);
+        assertEquals("foo", cookies[0].getName());
+        assertEquals("1", cookies[0].getValue());
+        assertEquals("foo", cookies[1].getName());
+        assertEquals("2", cookies[1].getValue());
+    }
+
+    @Test
+    void getCookiesPreservesValuesVerbatim() {
+        Cookie[] encodedCookies = cookieRequest("foo=hello%20world").getCookies();
+
+        assertEquals(1, encodedCookies.length);
+        assertEquals("hello%20world", encodedCookies[0].getValue());
+
+        Cookie[] emptyCookies = cookieRequest("foo=").getCookies();
+
+        assertEquals(1, emptyCookies.length);
+        assertEquals("foo", emptyCookies[0].getName());
+        assertEquals("", emptyCookies[0].getValue());
+    }
+
+    @Test
+    void getCookiesReturnsNullForMalformedHeaderWithoutThrowing() {
+        assertNull(assertDoesNotThrow(() -> cookieRequest("=;;garbage").getCookies()));
+        assertNull(assertDoesNotThrow(() -> cookieRequest("").getCookies()));
+    }
+
+    @Test
+    void getCookiesReturnsNullWhenNoCookieHeader() {
+        assertNull(cookieRequest().getCookies());
     }
 }

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -360,5 +361,21 @@ class NettyHttpServletRequestTest {
     @Test
     void getCookiesReturnsNullWhenNoCookieHeader() {
         assertNull(cookieRequest().getCookies());
+    }
+
+    @Test
+    void getCookiesReturnsDefensiveCopyButCachesElements() {
+        NettyHttpServletRequest request = cookieRequest("a=1; b=2");
+
+        Cookie[] first = request.getCookies();
+        Cookie[] second = request.getCookies();
+
+        // Each call hands back a fresh array (parity with getParameterValues), so a caller that
+        // mutates the returned array cannot corrupt a later getCookies() in the same request.
+        assertNotSame(first, second);
+        first[0] = null;
+        assertNotNull(request.getCookies()[0]);
+        // The shallow copy still shares element instances: cookies are parsed once, then cached.
+        assertSame(second[1], request.getCookies()[1]);
     }
 }

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponseTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponseTest.java
@@ -136,6 +136,30 @@ class NettyHttpServletResponseTest {
     }
 
     @Test
+    void addCookieTrimsPaddedSameSite() throws Exception {
+        var response = new NettyHttpServletResponse();
+        Cookie cookie = new Cookie("sid", "xyz");
+        // A padded value must not silently drop SameSite (weakening the intended policy).
+        cookie.setAttribute("SameSite", " Strict ");
+        response.addCookie(cookie);
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertTrue(httpResponse.headers().get(HttpHeaderNames.SET_COOKIE).contains("SameSite=Strict"));
+    }
+
+    @Test
+    void addCookieMapsPartitionedAttribute() throws Exception {
+        var response = new NettyHttpServletResponse();
+        Cookie cookie = new Cookie("sid", "xyz");
+        // CHIPS: presence of the Partitioned attribute (empty value) marks a partitioned cookie.
+        cookie.setAttribute("Partitioned", "");
+        response.addCookie(cookie);
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertTrue(httpResponse.headers().get(HttpHeaderNames.SET_COOKIE).contains("Partitioned"));
+    }
+
+    @Test
     void addCookieThrowsForInvalidCookieValue() {
         var response = new NettyHttpServletResponse();
         // The space is an invalid RFC 6265 cookie-octet. ServerCookieEncoder.STRICT rejects it,

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponseTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletResponseTest.java
@@ -3,11 +3,16 @@ package io.github.azholdaspaev.nettyloomspring.mvc.servlet;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NettyHttpServletResponseTest {
 
@@ -49,5 +54,109 @@ class NettyHttpServletResponseTest {
 
         FullHttpResponse httpResponse = response.toFullHttpResponse();
         assertEquals(0, httpResponse.content().readableBytes());
+    }
+
+    @Test
+    void addCookieWritesSetCookieHeader() throws Exception {
+        var response = new NettyHttpServletResponse();
+        response.addCookie(new Cookie("foo", "bar"));
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertTrue(httpResponse.headers().get(HttpHeaderNames.SET_COOKIE).startsWith("foo=bar"));
+    }
+
+    @Test
+    void addCookieWritesOneHeaderLinePerCookie() throws Exception {
+        var response = new NettyHttpServletResponse();
+        response.addCookie(new Cookie("a", "1"));
+        response.addCookie(new Cookie("b", "2"));
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertEquals(2, httpResponse.headers().getAll(HttpHeaderNames.SET_COOKIE).size());
+    }
+
+    @Test
+    void addCookieWritesEmptyValue() throws Exception {
+        var response = new NettyHttpServletResponse();
+        response.addCookie(new Cookie("empty", ""));
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertTrue(httpResponse.headers().get(HttpHeaderNames.SET_COOKIE).contains("empty="));
+    }
+
+    @Test
+    void addCookieWritesEmptyStringForNullValue() throws Exception {
+        var response = new NettyHttpServletResponse();
+        // The standard delete-cookie idiom passes a null value; jakarta Cookie permits it.
+        response.addCookie(new Cookie("logout", null));
+
+        FullHttpResponse httpResponse = assertDoesNotThrow(response::toFullHttpResponse);
+        assertTrue(httpResponse.headers().get(HttpHeaderNames.SET_COOKIE).startsWith("logout="));
+    }
+
+    @Test
+    void addCookieWritesAttributesWithSessionGuard() throws Exception {
+        var response = new NettyHttpServletResponse();
+        Cookie cookie = new Cookie("sid", "xyz");
+        cookie.setPath("/app");
+        cookie.setDomain("example.com");
+        cookie.setMaxAge(3600);
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        String setCookie = httpResponse.headers().get(HttpHeaderNames.SET_COOKIE);
+        assertTrue(setCookie.contains("Path=/app"));
+        assertTrue(setCookie.contains("Domain=example.com"));
+        assertTrue(setCookie.contains("Max-Age=3600"));
+        assertTrue(setCookie.contains("Secure"));
+        assertTrue(setCookie.contains("HTTPOnly"));
+    }
+
+    @Test
+    void addCookieOmitsMaxAgeForSessionCookie() throws Exception {
+        var response = new NettyHttpServletResponse();
+        // Default maxAge is -1 (session cookie): must not emit Max-Age.
+        response.addCookie(new Cookie("sid", "xyz"));
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertFalse(httpResponse.headers().get(HttpHeaderNames.SET_COOKIE).contains("Max-Age"));
+    }
+
+    @Test
+    void addCookieMapsSameSiteCaseInsensitively() throws Exception {
+        var response = new NettyHttpServletResponse();
+        Cookie cookie = new Cookie("sid", "xyz");
+        cookie.setAttribute("SameSite", "strict");
+        response.addCookie(cookie);
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        assertTrue(httpResponse.headers().get(HttpHeaderNames.SET_COOKIE).contains("SameSite=Strict"));
+    }
+
+    @Test
+    void addCookieThrowsForInvalidCookieValue() {
+        var response = new NettyHttpServletResponse();
+        // The space is an invalid RFC 6265 cookie-octet. ServerCookieEncoder.STRICT rejects it,
+        // and addCookie deliberately lets that IllegalArgumentException propagate (fail-fast,
+        // matching Tomcat's Rfc6265CookieProcessor) rather than dropping or mangling the cookie.
+        assertThrows(IllegalArgumentException.class,
+            () -> response.addCookie(new Cookie("sid", "invalid value")));
+    }
+
+    @Test
+    void addCookieIgnoresVersion() throws Exception {
+        var response = new NettyHttpServletResponse();
+        Cookie cookie = new Cookie("sid", "xyz");
+        cookie.setVersion(1);
+
+        assertDoesNotThrow(() -> response.addCookie(cookie));
+
+        FullHttpResponse httpResponse = response.toFullHttpResponse();
+        String setCookie = httpResponse.headers().get(HttpHeaderNames.SET_COOKIE);
+        assertTrue(setCookie.startsWith("sid=xyz"));
+        // RFC 6265 / Netty have no Version field — it is never emitted.
+        assertFalse(setCookie.contains("Version"));
     }
 }


### PR DESCRIPTION
Closes #11.

## What

Implements cookie read/write in the Netty servlet bridge, replacing the two stubs
(`getCookies()` returned `new Cookie[0]`; `addCookie()` was a no-op).

- **Request** — `NettyHttpServletRequest.getCookies()` parses the `Cookie` header(s)
  via `ServerCookieDecoder.STRICT.decodeAll(...)` (order-preserving; keeps duplicate
  names), mapping each to a `jakarta.servlet.http.Cookie`. Integrated into the lazy
  parsing style introduced by NL-40 (`ensureCookiesParsed()`), returning `null` when
  there are no cookies (Servlet-spec contract).
- **Response** — `NettyHttpServletResponse.addCookie()` maps the jakarta cookie to a
  Netty `DefaultCookie` (path/domain/maxAge/secure/httpOnly/SameSite), serializes with
  `ServerCookieEncoder.STRICT`, and emits one `Set-Cookie` header per cookie.

## Design decisions

- **Null cookie value → `""`** (matches Tomcat), so the standard `new Cookie(name, null)`
  delete idiom used by e.g. Spring Security logout no longer NPEs.
- **Invalid octets → fail fast** with `IllegalArgumentException` (parity with Tomcat's
  `Rfc6265CookieProcessor`), rather than silently dropping/mangling.
- **`version` is not propagated** — RFC 6265 / Netty have no Version field; jakarta
  deprecates `getVersion()`.
- **SameSite** is read via `getAttribute("SameSite")` (jakarta 6.1 exposes no typed
  `getSameSite()`), mapped case-insensitively to Netty's `CookieHeaderNames.SameSite`.

## Tests

- Unit: `NettyHttpServletRequestTest` (7 cookie cases: single, multi-pair ordering,
  multiple headers, duplicate names, verbatim/empty values, malformed tolerance, no-header)
  and `NettyHttpServletResponseTest` (+7: Set-Cookie emission, one-per-cookie, attributes,
  session-cookie guard, SameSite mapping, null-value, invalid-octet contract).
- Integration: `autoconfigure/cookie/` — full Spring Boot app + `@CookieValue` controller
  + `RestTestClient` round-trip (read, multi-in-order, missing-cookie 400, write round-trip,
  attribute round-trip, malformed tolerance).
- `./gradlew build` green (175 tests).

## Deferred (minor, from post-rebase review)

- Add an `assertSame` test locking `getCookies()` lazy-caching (siblings have one).
- `parseSameSite` could `trim()` before matching (silent drop on padded ` Strict `).

Neither is a blocker.