### PR TITLE
NL-49 Bind standard server.* properties (port, address, context-path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,20 +67,24 @@ public class DemoApplication {
 
 ```bash
 ./gradlew bootRun
-# server.netty.port=0 by default → OS picks a free port; set it explicitly in application.properties
+# Listens on server.port (default 8080); override it in application.properties
 ```
 
 ```properties
-server.netty.port=8080
+server.port=8080
 ```
 
 ## Configuration
 
-All properties live under the `server.netty` prefix (`NettyLoomProperties`).
+Standard knobs bind under Spring Boot's `server.*` namespace (`server.port`, `server.address`,
+`server.servlet.context-path`, `server.ssl.*`); Netty-only tuning lives under the `server.netty`
+prefix (`NettyLoomProperties`). See [ADR 0001](docs/adr/0001-server-properties-namespace.md).
 
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
-| `server.netty.port` | `int` | `0` | Listening port; `0` lets the OS select an available port |
+| `server.port` | `int` | `8080` | Listening port; `0` lets the OS select an available port |
+| `server.address` | `InetAddress` | all interfaces | Network address to bind; unset binds every interface |
+| `server.servlet.context-path` | `String` | `""` | Context path the application is mounted under |
 | `server.netty.boss-threads` | `int` | `1` | Netty boss group thread count (accepts connections) |
 | `server.netty.worker-threads` | `int` | `0` | Netty worker group thread count; `0` = Netty default (`CPU_COUNT * 2`) |
 | `server.netty.keep-alive` | `boolean` | `true` | TCP keep-alive on sockets |

--- a/docs/adr/0001-server-properties-namespace.md
+++ b/docs/adr/0001-server-properties-namespace.md
@@ -1,0 +1,86 @@
+# ADR 0001 — `server.*` vs `server.netty.*` configuration namespace
+
+- Status: Accepted
+- Date: 2026-07-03
+- Issue: [#49](https://github.com/azholdaspaev/netty-loom-spring/issues/49)
+
+## Context
+
+The library's value proposition is a drop-in Tomcat replacement. Before #49 it ignored Spring
+Boot's standard `server.*` namespace entirely: `NettyWebServerFactory` implemented the bare
+`ServletWebServerFactory`, so Boot's `ServerProperties` were never bound, and all configuration
+lived under a parallel `@ConfigurationProperties("server.netty")`. As a result `server.port=8080`
+silently bound a **random** port (only `server.netty.port`, default `0`, was honored), and
+`server.address` / `server.servlet.context-path` had no effect at all.
+
+Two adjacent issues forced a decision on where configuration should live:
+
+- **#16** wants TLS under the standard `server.ssl.*` namespace.
+- **#42** wants HTTP frame-size limits, which are Netty-specific tuning with no Boot equivalent.
+
+Without a rule, contributors would guess, and the two namespaces would drift into an inconsistent
+mix.
+
+## Decision
+
+**Ownership rule:**
+
+- **Standard knobs → `server.*`.** Anything Spring Boot already models — port, address,
+  context-path, SSL (`server.ssl.*`, #16), error handling — binds through Boot's
+  `ServerProperties` and `ServletWebServerFactoryCustomizer`. `NettyWebServerFactory` now extends
+  `AbstractConfigurableWebServerFactory` and implements `ConfigurableServletWebServerFactory`, so
+  these are pushed onto the factory before `getWebServer()` runs, exactly as the Tomcat/Jetty
+  factories work.
+- **Netty-only tuning → `server.netty.*`.** Knobs with no Boot equivalent — boss/worker thread
+  counts, TCP keep-alive, graceful-shutdown grace period, read-timeout, transport selection, and
+  the future frame-size limits (#42) — stay under `server.netty.*` (`NettyLoomProperties`).
+
+This reconciles #16 (SSL under `server.ssl.*`) and #42 (size limits under `server.netty.*`)
+without contradiction: the split is "does Spring Boot already own this concept?"
+
+**Removal of `server.netty.port`.** The port now comes only from `server.port`. The
+`@DefaultValue("0") int port` component was removed from `NettyLoomProperties`, and its entry was
+pruned from `additional-spring-configuration-metadata.json`. The old default of `0` (random port)
+is gone; `server.port` follows Boot's standard default of `8080`.
+
+## Consequences
+
+### Silent-ignore caveat
+
+`NettyLoomProperties` is a `@ConfigurationProperties` record, which binds with
+`ignoreUnknownFields = true` (the default). A stray `server.netty.port=...` left over from an
+earlier version is therefore **silently ignored — not a startup error**. Users migrating from
+`server.netty.port` to `server.port` who forget to change the key will get Boot's default `8080`
+with no warning. This is documented here and in the CHANGELOG.
+
+### SSL fails fast; other unsupported setters are no-ops
+
+Because the factory now extends `AbstractConfigurableWebServerFactory` and implements
+`ConfigurableServletWebServerFactory`, it **inherits** setters for capabilities the Netty server
+does not yet implement.
+
+`server.ssl.*` is treated specially: since silently serving plaintext while the application looks
+TLS-configured is a security footgun, `getWebServer()` **fails fast** with a clear
+`WebServerException` pointing at #16 whenever SSL is enabled. Wire TLS (#16) or set
+`server.ssl.enabled=false`.
+
+The remaining inherited setters are silent no-ops by design (the interface contract requires them);
+these `server.*` knobs appear configurable but currently have **no effect**:
+
+- `setHttp2`, `setCompression`, `setServerHeader` — not applied to the Netty pipeline.
+- `server.servlet.session.*` (`setSession`) — sessions are unsupported; timeout is deferred to #13.
+- `setMimeMappings` — no static resource serving.
+
+Wiring each is tracked by its own issue.
+
+### Bypassed error handling for out-of-context requests
+
+The context-path 404 is returned directly by the dispatcher, before the filter chain, so Spring
+Security's filter and Boot's `BasicErrorController` `/error` JSON are bypassed for out-of-context
+URIs — a plain 404, by design (an out-of-context URI would otherwise throw in Boot's
+`RequestPath.parse` and surface as a 500).
+
+## Scope
+
+In scope for #49: `server.port`, `server.address`, `server.servlet.context-path`. Session timeout
+(`server.servlet.session.timeout`) is deferred to #13.

--- a/netty-loom-spring-benchmarks/README.md
+++ b/netty-loom-spring-benchmarks/README.md
@@ -18,7 +18,7 @@ All three run an **identical** Spring MVC app (same controller, same two endpoin
 
 | Target | Server | Port | Config |
 |---|---|---|---|
-| `netty-loom` | this library's starter (Netty + one virtual thread per request) | 18080 | `server.netty.port=18080` |
+| `netty-loom` | this library's starter (Netty + one virtual thread per request) | 18080 | `server.port=18080` |
 | `tomcat-platform` | stock embedded Tomcat, classic thread-per-request | 18081 | `spring.threads.virtual.enabled=false` |
 | `tomcat-virtual` | embedded Tomcat dispatching onto virtual threads | 18082 | `spring.threads.virtual.enabled=true` |
 

--- a/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/NettyLoomAutoConfiguration.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/NettyLoomAutoConfiguration.java
@@ -9,9 +9,7 @@ import io.github.azholdaspaev.nettyloomspring.core.pipeline.DefaultNettyPipeline
 import io.github.azholdaspaev.nettyloomspring.core.pipeline.NamedChannelHandler;
 import io.github.azholdaspaev.nettyloomspring.core.pipeline.NettyPipelineConfigurer;
 import io.github.azholdaspaev.nettyloomspring.core.server.NettyIoHandlerFactory;
-import io.github.azholdaspaev.nettyloomspring.core.server.NettyServer;
 import io.github.azholdaspaev.nettyloomspring.core.server.NettyServerChannelInitializer;
-import io.github.azholdaspaev.nettyloomspring.core.server.NettyServerConfiguration;
 import io.github.azholdaspaev.nettyloomspring.mvc.handler.SpringHttpRequestDispatcher;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.DefaultNettyServletContext;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyServletContext;
@@ -23,8 +21,10 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.server.autoconfigure.servlet.ServletWebServerConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.DispatcherServlet;
 
 import java.util.List;
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 @AutoConfiguration(before = WebMvcAutoConfiguration.class)
 @EnableConfigurationProperties(NettyLoomProperties.class)
+@Import(ServletWebServerConfiguration.class)
 public class NettyLoomAutoConfiguration {
 
     private static final int MAX_HTTP_REQUEST_BODY_BYTES = 1024 * 1024;
@@ -42,34 +43,19 @@ public class NettyLoomAutoConfiguration {
     private static final int MAX_HTTP_CHUNK_SIZE = 10_000;
 
     @Bean
-    public NettyWebServerFactory nettyWebServerFactory(NettyServer nettyServer,
+    public NettyWebServerFactory nettyWebServerFactory(NettyIoHandlerFactory nettyIoHandlerFactory,
+                                                       NettyServerChannelInitializer nettyServerChannelInitializer,
+                                                       ChannelGroup nettyLoomChannelGroup,
                                                        NettyServletContext servletContext,
                                                        DispatcherServlet dispatcherServlet,
                                                        NettyLoomProperties properties) {
-        return new NettyWebServerFactory(nettyServer, servletContext, dispatcherServlet,
-            properties.shutdownGracePeriod());
+        return new NettyWebServerFactory(nettyIoHandlerFactory, nettyServerChannelInitializer,
+            nettyLoomChannelGroup, servletContext, dispatcherServlet, properties);
     }
 
     @Bean
-    public NettyServerConfiguration nettyServerConfiguration(NettyLoomProperties properties) {
-        return new NettyServerConfiguration(
-            properties.port(), properties.bossThreads(), properties.workerThreads(), properties.keepAlive(),
-            properties.transport()
-        );
-    }
-
-    @Bean
-    public NettyIoHandlerFactory nettyIoHandlerFactory(NettyServerConfiguration nettyServerConfiguration) {
-        return new NettyIoHandlerFactory(nettyServerConfiguration);
-    }
-
-    @Bean
-    public NettyServer nettyServer(NettyServerConfiguration nettyServerConfiguration,
-                                   NettyServerChannelInitializer nettyServerChannelInitializer,
-                                   NettyIoHandlerFactory nettyIoHandlerFactory,
-                                   ChannelGroup nettyLoomChannelGroup) {
-
-        return new NettyServer(nettyServerConfiguration, nettyServerChannelInitializer, nettyIoHandlerFactory, nettyLoomChannelGroup);
+    public NettyIoHandlerFactory nettyIoHandlerFactory(NettyLoomProperties properties) {
+        return new NettyIoHandlerFactory(properties.transport());
     }
 
     @Bean

--- a/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/properties/NettyLoomProperties.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/properties/NettyLoomProperties.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 
 @ConfigurationProperties("server.netty")
 public record NettyLoomProperties(
-    @DefaultValue("0") int port,
     @DefaultValue("1") int bossThreads,
     @DefaultValue("0") int workerThreads,
     @DefaultValue("true") boolean keepAlive,

--- a/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/server/NettyWebServerFactory.java
+++ b/netty-loom-spring-boot-starter/src/main/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/server/NettyWebServerFactory.java
@@ -1,47 +1,94 @@
 package io.github.azholdaspaev.nettyloomspring.autoconfigure.server;
 
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.properties.NettyLoomProperties;
+import io.github.azholdaspaev.nettyloomspring.core.server.NettyIoHandlerFactory;
 import io.github.azholdaspaev.nettyloomspring.core.server.NettyServer;
+import io.github.azholdaspaev.nettyloomspring.core.server.NettyServerChannelInitializer;
+import io.github.azholdaspaev.nettyloomspring.core.server.NettyServerConfiguration;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyFilterConfig;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyServletConfig;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.NettyServletContext;
 import io.github.azholdaspaev.nettyloomspring.mvc.servlet.RegisteredFilter;
+import io.netty.channel.group.ChannelGroup;
 import jakarta.servlet.ServletException;
+import org.springframework.boot.web.server.AbstractConfigurableWebServerFactory;
+import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.boot.web.server.WebServerException;
-import org.springframework.boot.web.server.servlet.ServletWebServerFactory;
+import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
+import org.springframework.boot.web.server.servlet.ServletWebServerSettings;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.web.servlet.DispatcherServlet;
 
-import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
-public class NettyWebServerFactory implements ServletWebServerFactory {
+public class NettyWebServerFactory extends AbstractConfigurableWebServerFactory
+    implements ConfigurableServletWebServerFactory {
 
-    private final NettyServer nettyServer;
+    private final ServletWebServerSettings settings = new ServletWebServerSettings();
+
+    private final NettyIoHandlerFactory ioHandlerFactory;
+    private final NettyServerChannelInitializer channelInitializer;
+    private final ChannelGroup channelGroup;
     private final NettyServletContext servletContext;
     private final DispatcherServlet dispatcherServlet;
-    private final Duration shutdownGracePeriod;
+    private final NettyLoomProperties properties;
 
-    public NettyWebServerFactory(NettyServer nettyServer,
+    public NettyWebServerFactory(NettyIoHandlerFactory ioHandlerFactory,
+                                 NettyServerChannelInitializer channelInitializer,
+                                 ChannelGroup channelGroup,
                                  NettyServletContext servletContext,
                                  DispatcherServlet dispatcherServlet,
-                                 Duration shutdownGracePeriod) {
-        this.nettyServer = nettyServer;
+                                 NettyLoomProperties properties) {
+        this.ioHandlerFactory = ioHandlerFactory;
+        this.channelInitializer = channelInitializer;
+        this.channelGroup = channelGroup;
         this.servletContext = servletContext;
         this.dispatcherServlet = dispatcherServlet;
-        this.shutdownGracePeriod = shutdownGracePeriod;
+        this.properties = properties;
+    }
+
+    @Override
+    public ServletWebServerSettings getSettings() {
+        return settings;
     }
 
     @Override
     public WebServer getWebServer(ServletContextInitializer... initializers) {
+        verifySslNotConfigured();
+        // Set the context path before the initializer/filter/servlet startup phases so any component
+        // that reads ServletContext.getContextPath() during onStartup/init sees the configured value,
+        // as the Jakarta contract requires (rather than the default "").
+        servletContext.setContextPath(getContextPath());
         initializeServletContext(initializers);
         initializeFilters();
         initializeDispatcherServlet();
-        return new NettyWebServer(nettyServer, shutdownGracePeriod);
+        NettyServerConfiguration configuration = new NettyServerConfiguration(
+            getPort(), getAddress(), properties.bossThreads(), properties.workerThreads(),
+            properties.keepAlive());
+        NettyServer nettyServer = new NettyServer(configuration, channelInitializer, ioHandlerFactory, channelGroup);
+        return new NettyWebServer(nettyServer, properties.shutdownGracePeriod());
+    }
+
+    private void verifySslNotConfigured() {
+        // Because this factory is a ConfigurableServletWebServerFactory, Boot binds server.ssl.* onto it,
+        // but the Netty pipeline has no SslHandler yet (issue #16). Fail fast rather than silently serving
+        // plaintext while the application looks TLS-configured.
+        if (Ssl.isEnabled(getSsl())) {
+            throw new WebServerException("server.ssl.* is configured but netty-loom-spring does not support "
+                + "TLS yet (see issue #16). Remove server.ssl.* or set server.ssl.enabled=false.", null);
+        }
     }
 
     private void initializeServletContext(ServletContextInitializer... initializers) {
-        for (ServletContextInitializer initializer : initializers) {
+        // Run both the container-supplied initializers and any registered on this factory via the
+        // inherited addInitializers/setInitializers (stored in the settings), mirroring the merge that
+        // AbstractServletWebServerFactory performs for Tomcat/Jetty.
+        List<ServletContextInitializer> merged = new ArrayList<>(List.of(initializers));
+        merged.addAll(getSettings().getInitializers());
+        for (ServletContextInitializer initializer : merged) {
             try {
                 initializer.onStartup(servletContext);
             } catch (ServletException e) {

--- a/netty-loom-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/netty-loom-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -7,10 +7,6 @@
   ],
   "properties": [
     {
-      "name": "server.netty.port",
-      "description": "TCP port the Netty server binds to. Use 0 to let the OS assign an ephemeral port (useful for tests)."
-    },
-    {
       "name": "server.netty.boss-threads",
       "description": "Number of threads in the boss event loop group that accepts incoming connections. One is typically sufficient."
     },
@@ -52,15 +48,6 @@
         {
           "value": "kqueue",
           "description": "macOS/BSD native transport. Fails fast if unavailable."
-        }
-      ]
-    },
-    {
-      "name": "server.netty.port",
-      "values": [
-        {
-          "value": 0,
-          "description": "Bind to an ephemeral port chosen by the operating system."
         }
       ]
     },

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/ContextPathIntegrationTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/ContextPathIntegrationTest.java
@@ -1,0 +1,82 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.contextpath;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.contextpath.app.ContextPathTestApplication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.client.RestTestClient;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Issue #49: {@code server.servlet.context-path} must mount the application under the given path.
+ * In-context requests route (200); out-of-context requests are rejected (404). {@code RestTestClient}
+ * auto-prepends the context path to relative URIs, so out-of-context requests use an absolute URL via
+ * {@link LocalServerPort}.
+ */
+@AutoConfigureRestTestClient
+@SpringBootTest(
+    classes = ContextPathTestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@TestPropertySource(properties = "server.servlet.context-path=/app")
+class ContextPathIntegrationTest {
+
+    @Autowired
+    private RestTestClient restTestClient;
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void relativeRequestIsMountedUnderContextPath() {
+        // RestTestClient prepends "/app" to the relative URI, so this hits /app/hello.
+        restTestClient.get().uri("/hello")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("/app");
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void inContextAbsoluteRequestRoutes() throws Exception {
+        HttpResponse<String> response = get("http://localhost:" + port + "/app/hello");
+
+        assertEquals(200, response.statusCode());
+        assertEquals("/app", response.body());
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void outOfContextAbsoluteRequestYields404() throws Exception {
+        HttpResponse<String> response = get("http://localhost:" + port + "/hello");
+
+        assertEquals(404, response.statusCode());
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void filterMappedByContextRelativePatternMatches() {
+        restTestClient.get().uri("/hello")
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().valueEquals("X-Ctx-Filter", "yes");
+    }
+
+    private static HttpResponse<String> get(String uri) throws Exception {
+        return HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder(URI.create(uri)).build(),
+            HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/ContextPathStartupTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/ContextPathStartupTest.java
@@ -1,0 +1,45 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.contextpath;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.contextpath.app.ContextPathTestApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Issue #49 review finding #1: the configured {@code server.servlet.context-path} must be visible to
+ * startup initializers. The Jakarta contract requires {@link jakarta.servlet.ServletContext#getContextPath()}
+ * to be valid during {@link org.springframework.boot.web.servlet.ServletContextInitializer#onStartup},
+ * so a factory-registered initializer must observe {@code /app}, not the default {@code ""}.
+ */
+@SpringBootTest(
+    classes = {ContextPathTestApplication.class, ContextPathStartupTest.CaptureConfig.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@TestPropertySource(properties = "server.servlet.context-path=/app")
+class ContextPathStartupTest {
+
+    @Test
+    void contextPathIsVisibleToStartupInitializers() {
+        assertEquals("/app", CaptureConfig.CAPTURED.get(),
+            "an initializer registered on the factory should see the configured context path at onStartup");
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class CaptureConfig {
+
+        static final AtomicReference<String> CAPTURED = new AtomicReference<>();
+
+        @Bean
+        WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> contextPathCapturingCustomizer() {
+            return factory -> factory.addInitializers(servletContext -> CAPTURED.set(servletContext.getContextPath()));
+        }
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/app/ContextPathController.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/app/ContextPathController.java
@@ -1,0 +1,14 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.contextpath.app;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ContextPathController {
+
+    @GetMapping("/hello")
+    public String hello(HttpServletRequest request) {
+        return request.getContextPath();
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/app/ContextPathTestApplication.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/app/ContextPathTestApplication.java
@@ -1,0 +1,12 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.contextpath.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ContextPathTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ContextPathTestApplication.class, args);
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/app/ContextPathTestConfig.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/contextpath/app/ContextPathTestConfig.java
@@ -1,0 +1,36 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.contextpath.app;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+public class ContextPathTestConfig {
+
+    // Mapped by the context-relative pattern "/hello" (the servlet path), proving filter matching
+    // uses the in-context path rather than the full request URI once a context path is set.
+    @Bean
+    FilterRegistrationBean<Filter> contextPathFilter() {
+        var registration = new FilterRegistrationBean<Filter>(new HeaderFilter());
+        registration.addUrlPatterns("/hello");
+        return registration;
+    }
+
+    private static final class HeaderFilter implements Filter {
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+            ((HttpServletResponse) response).setHeader("X-Ctx-Filter", "yes");
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/initializer/FactoryInitializerTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/initializer/FactoryInitializerTest.java
@@ -1,0 +1,42 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.initializer;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.smoke.app.SmokeNettyLoomApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@link ServletContextInitializer} registered on the factory via the inherited
+ * {@code addInitializers(...)} (the supported {@link WebServerFactoryCustomizer} extension point) must
+ * actually run at startup, alongside the container-supplied initializers.
+ */
+@SpringBootTest(
+    classes = {SmokeNettyLoomApplication.class, FactoryInitializerTest.FactoryInitializerConfig.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class FactoryInitializerTest {
+
+    @Test
+    void factoryRegisteredInitializerRuns() {
+        assertTrue(FactoryInitializerConfig.INITIALIZED.get(),
+            "initializer added via factory.addInitializers should have run during getWebServer()");
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class FactoryInitializerConfig {
+
+        static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
+
+        @Bean
+        WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> initializerRegisteringCustomizer() {
+            return factory -> factory.addInitializers(servletContext -> INITIALIZED.set(true));
+        }
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/port/ServerPortBindingTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/port/ServerPortBindingTest.java
@@ -1,0 +1,69 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.port;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.smoke.app.SmokeNettyLoomApplication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.server.context.WebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.util.TestSocketUtils;
+
+import java.net.BindException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Issue #25 compat gate: the standard {@code server.port} must bind the Netty server to the exact
+ * chosen port. A fixed port is required (not {@code RANDOM_PORT}, which forces {@code server.port=0}
+ * and can never observe a specific value), which means a free port has to be picked in advance. That
+ * pick-then-rebind carries an inherent TOCTOU window, so the test retries on the rare bind collision
+ * rather than flaking CI.
+ */
+class ServerPortBindingTest {
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void shouldBindStandardServerPort() throws Exception {
+        BindException lastBindFailure = null;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            int chosenPort = TestSocketUtils.findAvailableTcpPort();
+            try (ConfigurableApplicationContext context = new SpringApplicationBuilder(SmokeNettyLoomApplication.class)
+                .properties("server.port=" + chosenPort)
+                .run()) {
+
+                int boundPort = ((WebServerApplicationContext) context).getWebServer().getPort();
+                assertEquals(chosenPort, boundPort);
+
+                HttpResponse<String> response = HttpClient.newHttpClient().send(
+                    HttpRequest.newBuilder(URI.create("http://localhost:" + chosenPort + "/get")).build(),
+                    HttpResponse.BodyHandlers.ofString());
+                assertEquals(200, response.statusCode());
+                return;
+            } catch (RuntimeException e) {
+                BindException bindFailure = findBindFailure(e);
+                if (bindFailure == null) {
+                    throw e;
+                }
+                // The chosen port was taken between selection and bind; retry with a fresh one.
+                lastBindFailure = bindFailure;
+            }
+        }
+        throw new AssertionError("server.port binding lost the race " + MAX_ATTEMPTS + " times", lastBindFailure);
+    }
+
+    private static BindException findBindFailure(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof BindException bindException) {
+                return bindException;
+            }
+        }
+        return null;
+    }
+}

--- a/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/ssl/SslNotSupportedTest.java
+++ b/netty-loom-spring-boot-starter/src/test/java/io/github/azholdaspaev/nettyloomspring/autoconfigure/ssl/SslNotSupportedTest.java
@@ -1,0 +1,40 @@
+package io.github.azholdaspaev.nettyloomspring.autoconfigure.ssl;
+
+import io.github.azholdaspaev.nettyloomspring.autoconfigure.smoke.app.SmokeNettyLoomApplication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * TLS is not implemented yet (issue #16). Because the factory is now a
+ * {@code ConfigurableServletWebServerFactory}, Boot binds {@code server.ssl.*} onto it; the server must
+ * fail fast at startup rather than silently serve plaintext while appearing TLS-configured.
+ */
+class SslNotSupportedTest {
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void shouldFailFastWhenSslEnabled() {
+        RuntimeException failure = assertThrows(RuntimeException.class, () ->
+            new SpringApplicationBuilder(SmokeNettyLoomApplication.class)
+                .properties("server.port=0", "server.ssl.enabled=true")
+                .run());
+
+        assertTrue(messageChainMentions(failure, "issue #16"),
+            "startup failure should point at issue #16; was: " + failure);
+    }
+
+    private static boolean messageChainMentions(Throwable throwable, String needle) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause.getMessage() != null && cause.getMessage().contains(needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyIoHandlerFactory.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyIoHandlerFactory.java
@@ -18,9 +18,9 @@ public class NettyIoHandlerFactory {
 
     private final NettyTransport transport;
 
-    public NettyIoHandlerFactory(NettyServerConfiguration configuration) {
-        this.transport = NettyTransport.resolve(configuration.transport(), Epoll.isAvailable(), KQueue.isAvailable());
-        log.info("Netty transport selected: {}", transport);
+    public NettyIoHandlerFactory(String transport) {
+        this.transport = NettyTransport.resolve(transport, Epoll.isAvailable(), KQueue.isAvailable());
+        log.info("Netty transport selected: {}", this.transport);
     }
 
     public IoHandlerFactory getIoHandlerFactory() {

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServer.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServer.java
@@ -100,8 +100,16 @@ public class NettyServer {
     }
 
     public int getPort() {
-        InetSocketAddress address = resolvedAddress();
+        InetSocketAddress address = getBoundAddress();
         return address == null ? configuration.port() : address.getPort();
+    }
+
+    public InetSocketAddress getBoundAddress() {
+        RunningState current = state;
+        if (current != null && current.serverChannel().localAddress() instanceof InetSocketAddress addr) {
+            return addr;
+        }
+        return null;
     }
 
     public boolean isRunning() {
@@ -115,7 +123,7 @@ public class NettyServer {
             .childHandler(channelInitializer)
             .option(ChannelOption.SO_BACKLOG, 128)
             .childOption(ChannelOption.SO_KEEPALIVE, configuration.keepAlive());
-        return bootstrap.bind(configuration.port()).sync().channel();
+        return bootstrap.bind(new InetSocketAddress(configuration.address(), configuration.port())).sync().channel();
     }
 
     private boolean drainOrForceClose(Deadline deadline) throws InterruptedException {
@@ -144,14 +152,6 @@ public class NettyServer {
 
     private EventLoopGroup newEventLoopGroup(int threads) {
         return new MultiThreadIoEventLoopGroup(threads, ioHandlerFactory.getIoHandlerFactory());
-    }
-
-    private InetSocketAddress resolvedAddress() {
-        RunningState current = state;
-        if (current != null && current.serverChannel().localAddress() instanceof InetSocketAddress addr) {
-            return addr;
-        }
-        return null;
     }
 
     private record RunningState(Channel serverChannel, EventLoopGroup bossGroup, EventLoopGroup workerGroup) {

--- a/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerConfiguration.java
+++ b/netty-loom-spring-core/src/main/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerConfiguration.java
@@ -2,8 +2,8 @@ package io.github.azholdaspaev.nettyloomspring.core.server;
 
 public record NettyServerConfiguration(
     int port,
+    java.net.InetAddress address,
     int bossThreads,
     int workerThreads,
-    boolean keepAlive,
-    String transport
+    boolean keepAlive
 ) {}

--- a/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerTest.java
+++ b/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyServerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.ConnectException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.time.Duration;
@@ -27,12 +28,16 @@ class NettyServerTest {
 
     @BeforeEach
     void setup() {
-        NettyServerConfiguration configuration = new NettyServerConfiguration(0, 0, 0, false, "auto");
+        nettyServer = newServer(null);
+    }
+
+    private static NettyServer newServer(InetAddress address) {
+        NettyServerConfiguration configuration = new NettyServerConfiguration(0, address, 0, 0, false);
         NettyPipelineConfigurer pipelineConfigurer = new DefaultNettyPipelineConfigurer(List.of());
         ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
         NettyServerChannelInitializer channelInitializer = new NettyServerChannelInitializer(pipelineConfigurer, channelGroup);
-        NettyIoHandlerFactory nettyIoHandlerFactory = new NettyIoHandlerFactory(configuration);
-        nettyServer = new NettyServer(configuration, channelInitializer, nettyIoHandlerFactory, channelGroup);
+        NettyIoHandlerFactory nettyIoHandlerFactory = new NettyIoHandlerFactory("auto");
+        return new NettyServer(configuration, channelInitializer, nettyIoHandlerFactory, channelGroup);
     }
 
     @AfterEach
@@ -70,6 +75,24 @@ class NettyServerTest {
     void shouldReturnPort() {
         nettyServer.start();
 
+        assertTrue(nettyServer.getPort() > 0);
+    }
+
+    @Test
+    void shouldBindToConfiguredAddress() {
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        nettyServer = newServer(loopback);
+        nettyServer.start();
+
+        assertEquals(loopback, nettyServer.getBoundAddress().getAddress());
+        assertTrue(nettyServer.getPort() > 0);
+    }
+
+    @Test
+    void shouldBindToWildcardWhenAddressNull() {
+        nettyServer.start();
+
+        assertTrue(nettyServer.getBoundAddress().getAddress().isAnyLocalAddress());
         assertTrue(nettyServer.getPort() > 0);
     }
 

--- a/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyTransportTest.java
+++ b/netty-loom-spring-core/src/test/java/io/github/azholdaspaev/nettyloomspring/core/server/NettyTransportTest.java
@@ -85,7 +85,7 @@ class NettyTransportTest {
     @EnabledOnOs(OS.LINUX)
     void selectsEpollOnLinux() {
         assertTrue(Epoll.isAvailable(), "epoll native library must be on the classpath on Linux");
-        NettyIoHandlerFactory factory = new NettyIoHandlerFactory(configWith("auto"));
+        NettyIoHandlerFactory factory = new NettyIoHandlerFactory("auto");
         assertEquals(EpollServerSocketChannel.class, factory.getServerChannelClass());
     }
 
@@ -93,17 +93,13 @@ class NettyTransportTest {
     @EnabledOnOs(OS.MAC)
     void selectsKqueueOnMac() {
         assertTrue(KQueue.isAvailable(), "kqueue native library must be on the classpath on macOS");
-        NettyIoHandlerFactory factory = new NettyIoHandlerFactory(configWith("auto"));
+        NettyIoHandlerFactory factory = new NettyIoHandlerFactory("auto");
         assertEquals(KQueueServerSocketChannel.class, factory.getServerChannelClass());
     }
 
     @Test
     void nioFactorySelectsNioServerChannel() {
-        NettyIoHandlerFactory factory = new NettyIoHandlerFactory(configWith("nio"));
+        NettyIoHandlerFactory factory = new NettyIoHandlerFactory("nio");
         assertEquals(NioServerSocketChannel.class, factory.getServerChannelClass());
-    }
-
-    private static NettyServerConfiguration configWith(String transport) {
-        return new NettyServerConfiguration(0, 0, 0, false, transport);
     }
 }

--- a/netty-loom-spring-example-netty/src/main/resources/application.properties
+++ b/netty-loom-spring-example-netty/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=netty-loom
-server.netty.port=18080
+server.port=18080

--- a/netty-loom-spring-example-netty/src/test/java/io/github/azholdaspaev/nettyloomspring/example/netty/BenchmarkControllerTest.java
+++ b/netty-loom-spring-example-netty/src/test/java/io/github/azholdaspaev/nettyloomspring/example/netty/BenchmarkControllerTest.java
@@ -13,8 +13,7 @@ import java.util.concurrent.TimeUnit;
 @AutoConfigureRestTestClient
 @SpringBootTest(
     classes = NettyExampleApplication.class,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = "server.netty.port=0"
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 class BenchmarkControllerTest {
 

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/handler/SpringHttpRequestDispatcher.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/handler/SpringHttpRequestDispatcher.java
@@ -10,6 +10,7 @@ import io.github.azholdaspaev.nettyloomspring.mvc.servlet.RegisteredFilter;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.DispatcherServlet;
 
 import java.util.List;
@@ -29,11 +30,25 @@ public class SpringHttpRequestDispatcher implements HttpRequestDispatcher {
     @Override
     public FullHttpResponse handle(FullHttpRequest request, HttpConnectionMetadata connection) throws Exception {
         NettyHttpServletRequest servletRequest = new NettyHttpServletRequest(request, connection, servletContext);
+
+        String contextPath = servletContext.getContextPath();
+        String requestURI = servletRequest.getRequestURI();
+        // Out-of-context request: reject with a plain 404 before running filters or the servlet. Boot's
+        // PathPatternParser would otherwise throw on a URI outside the context path. Building the request
+        // first (a cheap, side-effect-free URI parse) lets the check reuse its already-parsed path.
+        if (!NettyServletContext.ROOT_CONTEXT_PATH.equals(contextPath)
+            && !(requestURI.equals(contextPath) || requestURI.startsWith(contextPath + "/"))) {
+            NettyHttpServletResponse notFound = new NettyHttpServletResponse();
+            notFound.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return notFound.toFullHttpResponse();
+        }
+
         NettyHttpServletResponse servletResponse = new NettyHttpServletResponse();
 
-        String requestPath = servletRequest.getRequestURI();
+        // Filter URL patterns are context-relative, so match on the in-context servlet path.
+        String servletPath = servletRequest.getServletPath();
         List<RegisteredFilter> applicable = servletContext.getRegisteredFilters().stream()
-            .filter(filter -> filter.matches(requestPath, servletRequest.getDispatcherType()))
+            .filter(filter -> filter.matches(servletPath, servletRequest.getDispatcherType()))
             .toList();
 
         NettyFilterChain chain = new NettyFilterChain(applicable, terminal);

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/DefaultNettyServletContext.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/DefaultNettyServletContext.java
@@ -38,6 +38,7 @@ public class DefaultNettyServletContext implements NettyServletContext {
     // rebuilds it on next read. Registration is single-threaded at startup; reads happen after
     // server start, so the volatile field is sufficient for safe publication.
     private volatile List<RegisteredFilter> registeredFiltersSnapshot;
+    private volatile String contextPath = ROOT_CONTEXT_PATH;
 
     @Override
     public Object getAttribute(String name) {
@@ -182,8 +183,13 @@ public class DefaultNettyServletContext implements NettyServletContext {
     }
 
     @Override
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath == null ? ROOT_CONTEXT_PATH : contextPath;
+    }
+
+    @Override
     public String getContextPath() {
-        return "";
+        return contextPath;
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequest.java
@@ -246,7 +246,7 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getContextPath() {
-        return "";
+        return servletContext.getContextPath();
     }
 
     @Override
@@ -298,7 +298,9 @@ public class NettyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getServletPath() {
-        return "";
+        // In-context remainder of the request URI: "" when the request targets the context root,
+        // and identical to the full request URI when no context path is set.
+        return requestURI.substring(servletContext.getContextPath().length());
     }
 
     @Override

--- a/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyServletContext.java
+++ b/netty-loom-spring-mvc/src/main/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyServletContext.java
@@ -23,6 +23,14 @@ import java.util.Set;
 public interface NettyServletContext extends ServletContext {
 
     /**
+     * Context path value meaning the application is mounted at the server root (no prefix). Matches
+     * Spring Boot's {@code ContextPath} normalization, which represents the root as an empty string
+     * (never {@code "/"}). Used as the sentinel by {@link #getContextPath()} and the request path
+     * logic that strips this prefix.
+     */
+    String ROOT_CONTEXT_PATH = "";
+
+    /**
      * Returns the executable filter registrations (those backed by a live {@link Filter}
      * instance) in registration order, which already reflects Spring Boot's {@code @Order}
      * resolution. Not part of the Jakarta {@link ServletContext} contract.
@@ -30,6 +38,13 @@ public interface NettyServletContext extends ServletContext {
     default List<RegisteredFilter> getRegisteredFilters() {
         return List.of();
     }
+
+    /**
+     * Sets the context path this server is mounted under, as resolved from
+     * {@code server.servlet.context-path}. A {@code null} value means the root context ({@code ""}).
+     * Not part of the Jakarta {@link ServletContext} contract.
+     */
+    void setContextPath(String contextPath);
 
     @Override
     default String getContextPath() {

--- a/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
+++ b/netty-loom-spring-mvc/src/test/java/io/github/azholdaspaev/nettyloomspring/mvc/servlet/NettyHttpServletRequestTest.java
@@ -57,6 +57,39 @@ class NettyHttpServletRequestTest {
         return new NettyHttpServletRequest(nettyRequest, connection, new DefaultNettyServletContext());
     }
 
+    private static NettyHttpServletRequest requestWithContext(String uri, String contextPath) {
+        var context = new DefaultNettyServletContext();
+        context.setContextPath(contextPath);
+        return new NettyHttpServletRequest(
+            new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri),
+            new HttpConnectionMetadata("", 0, "", 0, false),
+            context);
+    }
+
+    @Test
+    void contextPathAndServletPathReadTheServletContext() {
+        // Context "/app", URI "/app/hello?x=1": context path is the mount, servlet path is the
+        // in-context remainder, and the request URI stays the full decoded path.
+        var inContext = requestWithContext("/app/hello?x=1", "/app");
+        assertEquals("/app", inContext.getContextPath());
+        assertEquals("/app/hello", inContext.getRequestURI());
+        assertEquals("/hello", inContext.getServletPath());
+
+        // Request exactly at the context root: the servlet path is empty.
+        var atContextRoot = requestWithContext("/app", "/app");
+        assertEquals("/app", atContextRoot.getContextPath());
+        assertEquals("/app", atContextRoot.getRequestURI());
+        assertEquals("", atContextRoot.getServletPath());
+    }
+
+    @Test
+    void emptyContextLeavesPathGettersUnchanged() {
+        var noContext = requestWithContext("/hello", "");
+        assertEquals("", noContext.getContextPath());
+        assertEquals("/hello", noContext.getRequestURI());
+        assertEquals("/hello", noContext.getServletPath());
+    }
+
     @Test
     void networkGettersFromConnection() {
         var context = new DefaultNettyServletContext();


### PR DESCRIPTION
Closes #49.

## Problem

The library markets itself as a drop-in Tomcat replacement but ignored Spring Boot's standard `server.*` namespace. `NettyWebServerFactory` implemented the bare `ServletWebServerFactory`, so `ServerProperties` were never bound — `server.port=8080` silently bound a **random** port (only `server.netty.port`, default `0`, was honored), and `server.address` / `server.servlet.context-path` had no effect.

## Change

Make `NettyWebServerFactory` extend `AbstractConfigurableWebServerFactory` and implement `ConfigurableServletWebServerFactory`, so Boot's `ServletWebServerFactoryCustomizer` pushes `ServerProperties` onto the factory before `getWebServer()` runs — exactly as the Tomcat/Jetty factories work.

- **`server.port` / `server.address`** bind and take effect (`null` address → wildcard bind).
- **`server.servlet.context-path`** is threaded through `NettyServletContext.setContextPath` and honored in routing: in-context requests route, out-of-context requests get a plain 404; `getContextPath()` / `getServletPath()` derive from it. The context path is applied **before** the startup initializer/filter/servlet phases so it is visible during `onStartup`/`init` (Jakarta contract).
- **`server.netty.port` removed.** Standard port config lives under `server.port` only.
- **`server.ssl.*`** fails fast at startup — TLS isn't implemented yet (#16) — rather than silently serving plaintext under a TLS-looking config.

## Namespace decision (ADR)

`docs/adr/0001-server-properties-namespace.md` records the ownership rule reconciling #16 (SSL) and #42 (size limits): **standard knobs → `server.*`** (port, address, context-path, ssl, error handling); **Netty-only tuning → `server.netty.*`** (boss/worker threads, keep-alive, transport, timeouts, future frame-size limits).

## Tests

- `ServerPortBindingTest` — fixed `server.port` is actually bound (#25 compat gate; not `RANDOM_PORT`, which coincided with the old `server.netty.port=0` default).
- `ContextPathIntegrationTest` — in-context 200 / out-of-context 404 / context-relative filter matching.
- `ContextPathStartupTest` — context path is visible to factory-registered initializers at `onStartup`.
- `FactoryInitializerTest` — initializers added via `factory.addInitializers` run at startup.
- `SslNotSupportedTest` — startup fails fast, pointing at #16.

## Verification

`./gradlew build` — full suite green.